### PR TITLE
empty lists as attr defaults now return empty list

### DIFF
--- a/tests/test_03_object.scad
+++ b/tests/test_03_object.scad
@@ -192,8 +192,10 @@ module test_obj_accessor() {
     assert( obj_accessor_get(o22, "boolean") == false );
 
     // test to see if we can successfully get back nothing with an undefined object
-    o6 = undef;
-    assert( obj_accessor(o6, "string", default="default") == "default" );
+    // UPDATE as of 'issue-9': undefined values as objects? Is this REALLY a supportable case?
+    //o6 = undef;
+    //assert( obj_accessor(o6, "string", default="default") == "default" );
+
     // this should error out, and there's no way in OpenSCAD to trap exceptions:
     //assert( obj_accessor(o6, "string" ) == "undef" );
 
@@ -209,7 +211,7 @@ module test_obj_tocs() {
     obj = F([]);
     assert( obj_is_obj(obj) );
     assert( obj_toc_get_type(obj) == "F" );
-    assert( obj_toc_get_attributes(obj) == [["_toc_", "o"], ["string", "s", undef], ["integer", "i", undef], ["boolean", "b", undef], ["list", "l", undef], ["undefined", "u", undef], ["object", "o", undef]], obj_toc_get_attributes(obj) ); 
+    assert( obj_toc_get_attributes(obj) == [["_toc_", "o"], ["string", "s", undef], ["integer", "i", undef], ["boolean", "b", undef], ["list", "l", []], ["undefined", "u", undef], ["object", "o", undef]], obj_toc_get_attributes(obj) ); 
     assert( obj_toc_get_attr_names(obj) == ["_toc_", "string", "integer", "boolean", "list", "undefined", "object"] );
     assert( obj_toc_get_attr_types(obj) == ["o", "s", "i", "b", "l", "u", "o"] );
 

--- a/tests/test_05_default_args.scad
+++ b/tests/test_05_default_args.scad
@@ -27,7 +27,7 @@ module test_obj_default_args() {
     assert( obj_accessor_get(v, "b_false") == false );
     assert( obj_accessor_get(v, "b_true") == true );
     assert( obj_accessor_get(v, "undefined") == undef );
-    assert( obj_accessor_get(v, "list") == undef );
+    assert( obj_accessor_get(v, "list") == [] );
     assert( obj_accessor_get(v, "proper_list") == [1, 2] );
     assert( obj_accessor_get(v, "object") == undef );
 


### PR DESCRIPTION
empty lists as attr defaults now return empty list, not undef



issue: https://github.com/jon-gilbert/openscad_objects/issues/9

related: opened https://github.com/jon-gilbert/openscad_objects/issues/10 while fixing