### PR TITLE
Misc doc cleanup

### DIFF
--- a/.openscad_docsgen_rc
+++ b/.openscad_docsgen_rc
@@ -10,4 +10,5 @@ DefineHeader(BulletList): Links
 DefineHeader(Table;Headers=^Position|^Positional List Item|What It Represents): DefArgs
 DefineHeader(Table;Headers=^Position|^Name|What It Represents): Return Listing
 DefineHeader(Table;Headers=^Attribute Name|What It Represents): Attributes
+DefineHeader(Table;Headers=^Type ID|What It Represents): Type IDs
 DefineHeader(Table;Headers=^Function|What It Returns): Attribute Function Listing

--- a/object_common_functions.scad
+++ b/object_common_functions.scad
@@ -40,7 +40,6 @@ include <BOSL2/std.scad>
 // Synopsis: Create a generic Object
 // Usage:
 //   object = Object(name, attrs);
-//   object = Object(name, attrs, <vlist>);
 //   object = Object(name, attrs, <vlist=vlist>, <mutate=object>);
 // Description:
 //   Given an Object name as a string `name`, a list of attributes `attrs`, 
@@ -57,12 +56,24 @@ include <BOSL2/std.scad>
 //   `name[=data_type[=default]]`, where `name` is the name of the attribute; and, `data_type` is 
 //   one of the supported data types listed below in `ATTRIBUTE_DATA_TYPES`; and, `default` is 
 //   a default value for that attribute. 
-//   .
+//   ```openscad
+//   Object_Attributes = [
+//      "a1=s",            // defines "a1", a string attribute
+//      "a2=i=10"          // defines "a2", an integer attribute, with a default of 10
+//   ];
+//   ```
 //   When using the list form to define attributes, the attribute's defining format is a three-element list: 
 //   `[name, data_type, default]`. The three elements directly map to those in the string 
 //   format. Using a list format is required when the `default` is not easily represented in a 
 //   simple string (such as when the default is a list itself, or an object, or a pre-defined 
 //   constant such as `PI` or `CENTER`). 
+//   ```openscad
+//   Object_Attributes = [
+//      ["a1", "s"],             // defines "a1", a string attribute
+//      ["a2", "i", 10],         // defines "a2", an integer attribute, with a default of 10
+//      ["a3", "l", [1, 2, 3]],  // defines "a3", a list attribute, with a default list
+//   ];
+//   ```
 //   .
 //   **Pre-populating Objects with values with `vlist`:** 
 //   The `vlist` listing argument to `Object()` is a variable list of `[attribute, value]` lists. 

--- a/object_common_functions.scad
+++ b/object_common_functions.scad
@@ -1533,75 +1533,76 @@ function _attr_type_default_from_string_recast(type, value_as_string) =
 
 
 
-// ------------------------------------------------------------------------------------------------------------
-// Section: Support Functions
-//   These are pulled directly from the 507 Project. To keep warnings down, 
-//   they're prefixed with an underscore (`_`), but otherwise are direct copies. 
-//   . 
-//   The remainder of the functions that this LibFile relies on are present in 
-//   BOSL2, all from the set of functions that make managing lists in OpenSCAD easier. They are:
-//   `flatten()`, `in_list()`, `list_insert()`, `list_pad()`, `list_set()`, `list_shape()`, and `list_to_matrix()`.
-//
-// Function: _defined()
-// Synopsis: Good all-purpose "is this variable defined?" function
-// Usage:
-//   _defined(value);
-// Description:
-//   Given a variable, return true if the variable is defined. 
-//   This doesn't differenate `true` vs `false` - `false` is still defined. 
-//   `_defined()` tests to see if a string value is something other than `undef`, 
-//   or a list value is something other than `[]` (an empty list). 
-//   *Mnem: this tests if the var has a value.*
-// Arguments:
-//   value = The thing to test definition.
-// Example(NORENDER):
-//   _defined(undef);  // Returns: false
-//   _defined(1);      // Returns: true
-//   _defined(0);      // Returns: true
-//   _defined(-1);     // Returns: true
-//   _defined("a");    // Returns: true 
-//   _defined([]);     // Returns: false
-//   _defined(true);   // Returns: true
-//   _defined(false);  // Returns: true
+/// ------------------------------------------------------------------------------------------------------------
+/// Section: Support Functions
+///   These are pulled directly from the 507 Project. To keep warnings down, 
+///   they're prefixed with an underscore (`_`), but otherwise are direct copies. 
+///   . 
+///   The remainder of the functions that this LibFile relies on are present in 
+///   BOSL2, all from the set of functions that make managing lists in OpenSCAD easier. They are:
+///   `flatten()`, `in_list()`, `list_insert()`, `list_pad()`, `list_set()`, `list_shape()`, and `list_to_matrix()`.
+///
+/// Function: _defined()
+/// Synopsis: Good all-purpose "is this variable defined?" function
+/// Usage:
+///   _defined(value);
+/// Description:
+///   Given a variable, return true if the variable is defined. 
+///   This doesn't differenate `true` vs `false` - `false` is still defined. 
+///   `_defined()` tests to see if a string value is something other than `undef`, 
+///   or a list value is something other than `[]` (an empty list). 
+///   *Mnem: this tests if the var has a value.*
+/// Arguments:
+///   value = The thing to test definition.
+/// Example(NORENDER):
+///   _defined(undef);  // Returns: false
+///   _defined(1);      // Returns: true
+///   _defined(0);      // Returns: true
+///   _defined(-1);     // Returns: true
+///   _defined("a");    // Returns: true 
+///   _defined([]);     // Returns: false
+///   _defined(true);   // Returns: true
+///   _defined(false);  // Returns: true
 function _defined(a) = (is_list(a)) ? len(a) > 0 : !is_undef(a);
 
 
-// Function: _first()
-// Synopsis: Return the first "defined" value in a list
-// Usage:
-//   _first(list);
-// Description:
-//   Given a list of values, returns the first defined (as per `_defined()`) in the list.
-//   Because we're using `_defined()` to test each value in the list, 
-//   `false` is a valid candidate for return. 
-//   .
-//   If there's no suitable element that can be returned, `_first()` returns undef.  
-// Arguments:
-//   list = The list from which to examine for the first defined item. `list` can be comprised of any variable type that is testable by `_defined()`. 
-// Example(NORENDER):
-//   _first([undef, "a"]);       // Returns: "a"
-//   _first([0, 1]);             // Returns: 0         (because 0 is defined)
-//   _first([false, 1]);         // Returns: false     (because false is defined)
-//   _first([[]], "a"]);         // Returns: "a"       (because an empty list is undefined)
-//   _first([undef, [[]]);       // Returns: undef     (because there is no valid, defined element)
-// See Also: _defined()
+/// Function: _first()
+/// Synopsis: Return the first "defined" value in a list
+/// Usage:
+///   _first(list);
+/// Description:
+///   Given a list of values, returns the first defined (as per `_defined()`) in the list.
+///   Because we're using `_defined()` to test each value in the list, 
+///   `false` is a valid candidate for return. 
+///   .
+///   If there's no suitable element that can be returned, `_first()` returns undef.  
+/// Arguments:
+///   list = The list from which to examine for the first defined item. `list` can be comprised of any variable type that is testable by `_defined()`. 
+/// Example(NORENDER):
+///   _first([undef, "a"]);       // Returns: "a"
+///   _first([0, 1]);             // Returns: 0         (because 0 is defined)
+///   _first([false, 1]);         // Returns: false     (because false is defined)
+///   _first([[]], "a"]);         // Returns: "a"       (because an empty list is undefined)
+///   _first([undef, [[]]);       // Returns: undef     (because there is no valid, defined element)
+/// See Also: _defined()
 function _first(list) = [for (i = list) if (_defined(i)) i][0];
 
 
-// Function: _defined_len()
-// Synopsis: Return the number of defined elements in a list
-// Usage:
-//   _defined_len(list);
-// Description:
-//   Given a list of values, returns the number of defined elements in that 
-//   list. If there are no elements, or if all elements are undefined, returns `0`.
-// Arguments:
-//   list = A list of items to count. `list` can be comprised of any variable type that is testable by `_defined()`. 
-// Example(NORENDER):
-//   _defined_len([0, 1, 2]);         // Returns: 3
-//   _defined_len([undef, 1, 2]);     // Returns: 2
-// See Also: _defined()
+/// Function: _defined_len()
+/// Synopsis: Return the number of defined elements in a list
+/// Usage:
+///   _defined_len(list);
+/// Description:
+///   Given a list of values, returns the number of defined elements in that 
+///   list. If there are no elements, or if all elements are undefined, returns `0`.
+/// Arguments:
+///   list = A list of items to count. `list` can be comprised of any variable type that is testable by `_defined()`. 
+/// Example(NORENDER):
+///   _defined_len([0, 1, 2]);         // Returns: 3
+///   _defined_len([undef, 1, 2]);     // Returns: 2
+/// See Also: _defined()
 function _defined_len(list) = len([ for (i=list) if (_defined(i)) i]);
+
 
 function _assert_assign_if_defined(a, b, msg) = (_defined(a)) 
     ? assert( (b) ? b : a, msg ) a

--- a/object_common_functions.scad
+++ b/object_common_functions.scad
@@ -869,22 +869,26 @@ function obj_get_defaults(obj) = obj_toc_get_attr_defaults(obj);
 //   default is available, return that instead. Works pretty much like every 
 //   other OO model out there, easy-peasy. 
 //   ```openscad
-//      axle = Object("Axle", [["diameter", "i"], ["length", "i"]], 
-//                            [["diameter", 10],  ["length", undef]]);
+//      axle = Object("Axle", 
+//                    [["diameter", "i"], ["length", "i"]], 
+//                    [["diameter", 10],  ["length", undef]]
+//                    );
 //      echo( obj_accessor_get(axle, "diameter") );
 //      // ECHO: 10
 //   ```
 //   .
 //   "Setting" an attribute's value is a little more interesting, because OpenSCAD 
 //   doesn't let you change a variable after it's been declared: in other languages, 
-//   the data for a class or object is mutatable and liable to change, but in 
+//   the data for a class or object may be altered and is liable to change, but in 
 //   OpenSCAD you can't do that. So: instead of returning the new value, or 
 //   a "you changed this value" success flag, setting an attribute's value returns 
 //   _an entirely new Object_. The new Object has the newly-set attribute value, 
 //   and the original Object is unmodified.
 //   ```openscad
-//      axle = Object("Axle", [["diameter", "i"], ["length", "i"]], 
-//                            [["diameter", 10],  ["length", undef]]);
+//      axle = Object("Axle", 
+//                    [["diameter", "i"], ["length", "i"]], 
+//                    [["diameter", 10],  ["length", undef]]
+//                    );
 //      echo( obj_accessor_get(axle, "length") );
 //      // ECHO: undef
 //      axle2 = obj_accessor_set(axle, "length", nv=30);
@@ -892,7 +896,7 @@ function obj_get_defaults(obj) = obj_toc_get_attr_defaults(obj);
 //      // ECHO: 30
 //   ```
 //   .
-//   There's one mutatable accessor, `obj_accessor()`, that 
+//   There's one mutable accessor, `obj_accessor()`, that 
 //   can both `get` and `set` values by attribute name. There are also 
 //   two get- and set-specific accessors: `obj_accessor_get()` returns attributes in a 
 //   read-only manner; and, `obj_accessor_set()` returns a modifed object list after 
@@ -912,7 +916,7 @@ function obj_get_defaults(obj) = obj_toc_get_attr_defaults(obj);
 //   Basic accessor for object attributes. Given an object `obj` and an attribute name `name`, operates on that attribute. 
 //   The operation depends on what other options are passed. Calls to `obj_accessor()` with an `nv` (new-value) option 
 //   defined will create a new object based on `obj` with the new value set for `name`, and then will return that 
-//   new object (a "set" operation). 
+//   modified object list as `new_object` (a "set" operation). 
 //   .
 //   Calls to `obj_accessor()` without the `nv` option will look the current value of `name` up in the object and 
 //   return it (a "get" operation). "Get" operations can provide a `default` option, for when values aren't set. 
@@ -938,35 +942,24 @@ function obj_get_defaults(obj) = obj_toc_get_attr_defaults(obj);
 //   clear an object's attribute, use `obj_accessor_unset()`. To explicitly set an attribute to a new value, use 
 //   `obj_accessor_set()` (which will error out if `nv` is not defined). 
 // Example(NORENDER): direct "get" call to `obj_accessor()`:
-//   axle = Axle(["length", 30]);
-//   length = obj_accessor(axle, "length");
-//   // length == 30
-//   diameter = obj_accessor(axle, "diameter", default=10);
-//   // diameter == 10
-//   // (diameter is unset in the `axle` object, so the default of 10 is returned instead)
+//   obj = Object("ExampleObj", ["a1=i", "a2=i"], ["a1", 30]);
+//   a1 = obj_accessor(obj, "a1");
+//   // a1 == 30
+//   a2 = obj_accessor(obj, "a2", default=10);
+//   // a2 == undef 
+//   // (because `a2` is not set in `obj`, and there is no Object default, there is no value to return.)
+//   a2_2 = obj_accessor(obj, "a2", default=10);
+//   // a2_2 == 10
+//   // (`a2` is still unset in the `obj` object, but `default` was provided to `obj_accessor()`, so that default of 10 is returned instead)
 // Example(NORENDER): direct "set" calls to `obj_accessor()`:
-//   axle = Axle(["length", 30]);
-//   new_axle = obj_accessor(axle, "length", nv=6);
-//   // new_axle's `length` value is now 6. 
-//   // axle's `length` value is still 30.
+//   obj = Object("ExampleObj", ["a1=i", "a2=i"], ["a1", 30]);
+//   obj2 = obj_accessor(obj, "a1", nv=6);
+//   // obj2 is a new object, of the same type as `obj`; its `a1` value is now 6. 
+//   // obj's `a1` value is still 30.
 // Example(NORENDER): gotcha when providing `undef` as a new-value:
-//   axle = Axle([["diameter", 10], ["length", 30]]);
-//   new_axle = obj_accessor(axle, "length", nv=undef);
-//   // new_axle == 6, because obj_accessor() didn't see a value for `nv`, and instead of changing "length", its value was returned
-// Example(NORENDER): providing a class-specific "glue" accessor:
-//   function axle_acc(axle, name, default=undef, nv=undef) = obj_accesor(axle, name, default, nv);
-//   // ..
-//   axle = Axle([["diameter", 10], ["length", 30]]);
-//   dia = axle_acc(axle, "diameter");
-//   // dia == 10
-// Example(NORENDER): providing a class- and attribute-specific "glue" accessor:
-//   function axle_diameter(axle, default=undef, nv=undef) = obj_accessor(axle, "diameter", default=default, nv=nv);
-//   // ...
-//   axle = Axle([["diameter", 10], ["length", 30]]);
-//   diameter = axle_diameter(axle);
-//   // diameter == 10
-//   new_axle = axle_diameter(axle, nv=9);
-//   // new_axle == [9, 30] 
+//   obj = Object("ExampleObj", ["a1=i", "a2=i"], ["a1", 10, "a2", 30]);
+//   obj2 = obj_accessor(obj, "a1", nv=undef);
+//   // obj2 == 10, because `obj_accessor()` didn't see a value for `nv`: instead of changing `a1`, the value of `a1` was returned.
 // Todo: 
 //   when getting an attribute without a value and a default is provided, do a type check on the default value before returning
 // EXTERNAL - 
@@ -1013,7 +1006,7 @@ function obj_accessor(obj, name, default=undef, nv=undef, _consider_toc_default_
 //   value = obj_accessor_get(obj, name, <default=undef>);
 // Description:
 //   Basic "get" accessor for Objects. Given an object `obj` and attribute name `name`, `obj_accessor_get()` will look the current 
-//   value of `name` up in the object and return it (a "get" operation). 
+//   value of `name` up in the object and return it as `value` (a "get" operation). 
 //   .
 //   `obj_accessor_get()` is a simplified wrap around `obj_accessor()`, and the mechanics on how values are returned 
 //   are the same. "Get" operations can provide a `default` option, for when values aren't set. 
@@ -1023,7 +1016,7 @@ function obj_accessor(obj, name, default=undef, nv=undef, _consider_toc_default_
 //   for the object, `undef` will be returned. 
 // Arguments:
 //   obj = An Object list. No default. 
-//   name = The attribute name to access. The name must be present in `obj`'s TOC.
+//   name = The attribute name to access. The name must be present in `obj`'s TOC. No default.
 //   ---
 //   default = If provided, and if there is no existing value for `name` in the object `obj`, returns the value of `default` instead. 
 //   _consider_toc_default_values = If enabled, TOC-stored defaults will be returned according to the mechanics above. If disabled with `false`, the TOC default for a given attribute will not be considered as a viable return value. Default: `true`
@@ -1031,16 +1024,13 @@ function obj_accessor(obj, name, default=undef, nv=undef, _consider_toc_default_
 //   Note that `obj_accessor_get()` will accept a `nv` option, to make writing accessor glue easier, but 
 //   that `nv` option won't be evaluated or used. 
 // Example(NORENDER): direct calls to `obj_accessor_get()`:
-//   length = obj_accessor_get(axle, "length");
+//   obj = Object("ExampleObj", ["a1=i", "a2=i"], ["a1", 30]);
+//   value = obj_accessor_get(obj, "a1");
+//   // value == 30
 // Example(NORENDER): passing `nv` yields no change:
-//   retr = obj_accessor_get(axle, "length", nv=25);
-//   // retr == 30 (or, whatever the Axle's `length` previously was; the `nv` option is ignored)
-// Example(NORENDER): providing a class- and attribute-specific "glue" read-only accessor:
-//   function get_axle_length(axle, default=undef) = obj_accesor_get(axle, "length", default=default);
-//   // ..
-//   axle = Axle([["diameter", 10], ["length", 30]]);
-//   length = get_axle_length(axle);
-//   // length == 30
+//   obj = Object("ExampleObj", ["a1=i", "a2=i"], ["a1", 30]);
+//   value = obj_accessor_get(obj, "a1", nv=25);
+//   // value == 30  (the `nv` option is ignored)
 function obj_accessor_get(obj, name, nv=undef, default=undef, _consider_toc_default_values=true) = 
     let(
         _ = (_defined(nv))
@@ -1056,24 +1046,25 @@ function obj_accessor_get(obj, name, nv=undef, default=undef, _consider_toc_defa
 // Function: obj_accessor_set()
 // Synopsis: Generic write-only attribute accessor
 // Usage:
-//   new_obj = obj_accessor_set(obj, name, nv);
+//   new_object = obj_accessor_set(obj, name, nv);
 // Description:
 //   Basic "set" accessor for Objects. Given an object `obj`, an attribute name `name`, and a new value `nv` for that 
-//   attribute, `obj_accessor_set()` will return a new Object list with the updated value for that attribute. 
+//   attribute, `obj_accessor_set()` will return a new Object list with the updated value for that attribute as `new_object`.
 //   **The existing Object list is unmodified,** and a wholly new Object with the new value is returned instead. 
-//   .
-//   It is an error to call `obj_accessor_set()` without a new value (`nv`) passed. If the value of the attribute `name` 
-//   needs to be removed, use `obj_accessor_unset()` instead. 
 // Arguments:
 //   obj = An Object list. No default. 
-//   name = The attribute name to access. The name must be present in `obj`'s TOC.
-//   nv = If provided, `obj_accessor_set()` will update the value of the `name` attribute and return a new Object list. *The existing Object list is unmodified.*
+//   name = The attribute name to access. The name must be present in `obj`'s TOC. No default.
+//   nv = The new value to set as the new attribute. No default.
 // Continues:
+//   Unlike `obj_accessor()`, it is an error to call `obj_accessor_set()` without a new value (`nv`) passed. 
+//   If the value of the attribute `name` needs to be removed, use `obj_accessor_unset()` instead. 
+//   .
 //   Note that `obj_accessor_set()` will accept a `default` option, to make writing accessor 
-//   glue easier, but it won't be evaluated or used. 
+//   glue easier, but it will be neither evaluated nor used. 
 // Example(NORENDER): direct call to `obj_accessor_set()`
-//   new_axle = obj_accessor_set(axle, "length", nv=20);
-//   // new_axle's `length` attribute is now 20
+//   obj = Object("ExampleObj", ["a1=i", "a2=i"], ["a1", 30]);
+//   new_obj = obj_accessor_set(obj, "a1", nv=20);
+//   // new_obj's `a1` attribute is now 20
 // Example(NORENDER): providing a class- and attribute-specific "glue" write-only accessor:
 //   function set_axle_length(axle, nv) = obj_accessor_set(axle, "length", nv);
 //   // ..
@@ -1109,16 +1100,19 @@ function obj_accessor_set(obj, name, nv, default=undef) =
 // Usage:
 //   new_obj = obj_accessor_unset(obj, name);
 // Description:
-//   Basic "delete" accessor for Objects. A new Object will be returned 
+//   Basic "delete" accessor for Objects. Given an Object `obj` and an attribute 
+//   name `name`, a new Object will be returned 
 //   with the un-set attribute value. **The existing Object list is unmodified,** and a 
 //   wholly new Object list with the unset value is returned instead. 
 // Arguments:
 //   obj = An Object list. No default. 
-//   name = The attribute name to access. The name must be present in `obj`'s TOC.
+//   name = The attribute name to access. The name must be present in `obj`'s TOC. No default.
 // Example(NORENDER):
-//   axle = Axle([["diameter", 10], ["length", 30]]);
-//   new_axle = obj_accessor_unset(axle, "length");
-//   // new_axle == [["Axle", "diameter", "length"], 10, undef];
+//   obj = Object("ExampleObj", ["a1=i", "a2=i"], ["a1", 30]);
+//   new_obj = obj_accessor_unset(obj, "a1");
+//   // new_obj's `a1` attribute is now unset
+//   echo(obj_accessor_get(new_obj, "a1"));
+//   // emits: ECHO: undef
 // EXTERNAL - 
 //   list_set() (BOSL2);
 function obj_accessor_unset(obj, name) = 

--- a/object_common_functions.scad
+++ b/object_common_functions.scad
@@ -1130,7 +1130,7 @@ function obj_accessor_unset(obj, name) =
 //   list = obj_select(obj_list, idxs);
 // Description:
 //   Given a list of objects `obj_list` and a list of element indexes `idxs`, returns the
-//   objects in `obj_list` identified by their index position `idx`.
+//   objects in `obj_list` identified by their index position `idx` as a new list `list`.
 //   .
 //   The Objects need not be all of the same object type.
 // Arguments:
@@ -1151,13 +1151,13 @@ function obj_select(obj_list, idxs) =
 // Usage:
 //   list = obj_select_by_attr_defined(obj_list, attr);
 // Description:
-//   Given a list of Objects `obj_list` and an attribute name `attr`, return a list of
-//   all the Objects in `obj_list` that have the attribute `attr` defined.
+//   Given a list of Objects `obj_list` and an attribute name `attr`, return 
+//   all the Objects in `obj_list` that have the attribute `attr` defined as a list `list`.
 //   The Objects are returned in the order they appear in `obj_list`.
 //   The returned `list` of Objects may not be the same length as `obj_list`. The returned
 //   list `list` may have no elements in it.
 //   .
-//   The list of Objects need not be all of the same type.
+//   The list of Objects given need not be all of the same type.
 // Arguments:
 //   obj_list = A list of Objects
 //   attr = An attribute name
@@ -1174,7 +1174,7 @@ function obj_select_by_attr_defined(obj_list, attr) =
 //   list = obj_select_by_attr_value(obj_list, attr, value);
 // Description:
 //   Given an list of Objects `obj_list`, an attribute name `attr`, and a comparison value `value`, return
-//   a list of all Objects in `obj_list` whose value for `attr` matches `value`.
+//   all Objects in `obj_list` whose value for `attr` matches `value` as a list `list`.
 //   The Objects are returned in the order they appear in `obj_list`.
 //   .
 //   The Objects in `obj_list` need not be all of the same type.

--- a/object_common_functions.scad
+++ b/object_common_functions.scad
@@ -1110,10 +1110,13 @@ function obj_toc_build(name, attrs, mutate) =
     assert(_defined(attrs) || _defined(mutate), 
         "obj_toc_build: at least one of either attrs or mutate must be provided")
     let(
-        toc_attrs_with_type = [ for ( i=[0:len(attrs) - 1] ) attr_type_default_from_string_or_pairs(attrs[i]) ],
-        new_toc = list_insert(toc_attrs_with_type, [0], [name])
+        toc_attrs_with_type = (len(attrs) > 0)
+            ? [ for ( i=[0:len(attrs) - 1] ) attr_type_default_from_string_or_pairs(attrs[i]) ]
+            : []
     )
-    (obj_is_obj(mutate)) ? obj_toc(mutate) : new_toc;
+    (obj_is_obj(mutate)) 
+        ? obj_toc(mutate)
+        : list_insert(toc_attrs_with_type, [0], [name]);
 
 
 /// Function: obj_toc()

--- a/object_common_functions.scad
+++ b/object_common_functions.scad
@@ -9,7 +9,6 @@
 // FileSummary: Functions for creating and accessing object-like lists.
 // Includes:
 //   include <object_common_functions.scad>
-//
 
 include <BOSL2/std.scad>
 
@@ -26,66 +25,84 @@ include <BOSL2/std.scad>
 //
 // Function: Object()
 // Synopsis: Create a generic Object
-// Description:
-//   Creates a list of values from either `vlist` or `mutate` arguments with the same indexing as 
-//   `obj_attrs`. This resulting list can be treated as a loose "object". 
-//   `vlist` listing is a variable list of `[attribute, value]` lists. 
-//   Attribute pairs can be in any order. Attribute pairs may not be repeated. 
-//   Unspecified attributes will be set to `undef`. 
-//   `Object()` returns a new list that should be treated as an opaque object.
-//   .
-//   Optionally, an existing, similar object can be provided via the `mutate` argument: that 
-//   existing list will be used as the original set of object attribute values, and any 
-//   new values provided in `vlist` will take precedence.
 // Usage:
-//   object_list = Object("ObjectName", Obj_attributes, vlist);
-//   object_list = Object("ObjectName", Obj_attributes, vlist, mutate=object_list);
+//   object = Object(name, attrs);
+//   object = Object(name, attrs, <vlist>);
+//   object = Object(name, attrs, <vlist=vlist>, <mutate=object>);
+// Description:
+//   Given an Object name as a string `name`, a list of attributes `attrs`, 
+//   optionally a list of variable-listed values `vlist`, and optionally an existing 
+//   Object to model against `mutate`, create and return an Object-like list `object`.
+//   This Object will be a list that is `len(attrs) + 1` elements long: the first element
+//   will be a table-of-contents element containing the names and data types of each attribute;
+//   the remaining elements will be the values assigned to those attributes. 
+//   .
+//   **Defining what attributes the Object has with `attrs`:**
+//   The `attrs` argument is a list of attribute names, and optionally data types and defaults, 
+//   upon which the Object will be modeled. Each element in `attrs` is either a string or a list.
+//   In string form, the attribute's defining format is:
+//   `name[=data_type[=default]]`, where `name` is the name of the attribute; and, `data_type` is 
+//   one of the supported data types listed below in `ATTRIBUTE_DATA_TYPES`; and, `default` is 
+//   a default value for that attribute. 
+//   .
+//   When using the list form to define attributes, the attribute's defining format is a three-element list: 
+//   `[name, data_type, default]`. The three elements directly map to those in the string 
+//   format. Using a list format is required when the `default` is not easily represented in a 
+//   simple string (such as when the default is a list itself, or an object, or a pre-defined 
+//   constant such as `PI` or `CENTER`). 
+//   .
+//   **Pre-populating Objects with values with `vlist`:** 
+//   The `vlist` listing argument to `Object()` is a variable list of `[attribute, value]` lists. 
+//   Attribute pairs given in `vlist` can be in any order. Attribute pairs may not be repeated. 
+//   Unspecified attributes will be set to `undef`. 
+//   .
+//   **Modelling Objects from other Objects with `mutate`:**
+//   Optionally, an existing, similar Object can be provided via the `mutate` argument: that 
+//   existing Object list will be used as the original set of Object attribute values, with any 
+//   new values provided in `vlist` taking precedence.
 // Arguments:
-//   obj_name = The "name" of the object (think "classname"), for example: `Axle`. No default. 
-//   obj_attrs = The list of known attributes and their type for this object, eg: `["length=i", "style=s", "optional_attr=[]"]`. No default. 
+//   name = The "name" of the object (think "classname"). No default. 
+//   attrs = The list of known attributes, and optionally their type and default for this object. No default. 
 //   ---
-//   vlist = Variable list of attributes and values: `[ ["length", 10], ["style", "none"] ]`; **or,** a list of running attribute value pairing: `["length", 10, "style", "none"]`.  No default. 
-//   mutate = An existing Object of a similar `obj_name` type on which to pre-set values. Default: `[]`
-//
-// Example: empty object creation:
-//   Axle_attributes = ["diameter=i", "length=i"];
-//   function Axle(vlist=[], mutate=[]) = Object("Axle", Axle_attributes, vlist, mutate);
-//   echo(Axle());
-//   // emits: ECHO: "[["Axle", ["diameter", "i"], ["length", "i"]], undef, undef]
-//
-// Example: pre-populating object attributes at creation: 
-//   Axle_attributes = ["diameter=i", "length=i"];
-//   function Axle(vlist=[], mutate=[]) = Object("Axle", Axle_attributes, vlist, mutate);
-//   axle = Axle([["diameter", 10], ["length", 30]]);
-//   // axle == [["Axle", ["diameter", "i"], ["length", "i"]], 10, 30];
-//
-// Example: pre-populating again, but with a simpler `vlist`:
-//   Axle_attributes = ["diameter=i", "length=i"];
-//   function Axle(vlist=[], mutate=[]) = Object("Axle", Axle_attributes, vlist, mutate);
-//   axle2 = Axle(["diameter", 6]);
-//   // axle2 == [["Axle", ["diameter", "i"], ["length", "i"]], 6, undef];
-//
-// Example: showing how mutation works: 
-//   Axle_attributes = ["diameter=i", "length=i"];
-//   function Axle(vlist=[], mutate=[]) = Object("Axle", Axle_attributes, vlist, mutate);
-//   axle = Axle([["diameter", 10], ["length", 30]]);
-//   // axle == [["Axle", ["diameter", "i"], ["length", "i"]], 10, 30];
-//   axle2 = Axle([["length", 40]], mutate=axle);
-//   // axle2 == [["Axle", ["diameter", "i"], ["length", "i"]], 10, 40];
-//
+//   vlist = Variable list of attributes and values: `[ ["length", 10], ["style", "none"] ]`; **or,** a list of running attribute value pairing: `["length", 10, "style", "none"]`. Default: `[]` (which will produce an Object with no values).
+//   mutate = An existing Object of a similar `name` type on which to pre-set values. Default: `[]`
+// Continues:
+//   `Object()` returns a list that should be treated as an opaque object: reading values directly 
+//   from the `object` list, or modifying them manually into a new list, is not entirely safe.
+// Example(NORENDER): empty object creation:
+//   obj = Object("Obj", ["attr1=i", "attr2=s", "attr3=b=true"]);
+//   echo(obj);
+//   // emits: ECHO: [["Obj", ["attr1", "i", undef], ["attr2", "s", undef], ["attr3", "b", true]], undef, undef, undef]
+// Example(NORENDER): pre-populating object attributes at creation: 
+//   o = Object("Obj", ["attr1=i", "attr2=s", "attr3=b=true"], [["attr2", "hello"], ["attr3", false]]);
+//   echo(o);
+//   // emits: ECHO: [["Obj", ["attr1", "i", undef], ["attr2", "s", undef], ["attr3", "b", true]], undef, "hello", false]
+// Example(NORENDER): pre-populating again, but with a simpler `vlist`:
+//   o = Object("Obj", ["attr1=i", "attr2=s", "attr3=b=true"], ["attr2", "hello", "attr3", false]);
+//   echo(o);
+//   // emits: ECHO: [["Obj", ["attr1", "i", undef], ["attr2", "s", undef], ["attr3", "b", true]], undef, "hello", false]
+// Example(NORENDER): using `mutate` can carry values from a previous Object into a new one:
+//   O_attrs = ["attr1=i", "attr2=s", "attr3=b=true"];
+//   o = Object("Obj", O_attrs, [["attr2", "hello"], ["attr3", false]]);
+//   echo(o);
+//   o2 = Object("Obj", O_attrs, vlist=["attr1", 12], mutate=o);
+//   echo(o2);
+//   // emits:
+//   //   ECHO: [["Obj", ["attr1", "i", undef], ["attr2", "s", undef], ["attr3", "b", true]], undef, "hello", false]
+//   //   ECHO: [["Obj", ["attr1", "i", undef], ["attr2", "s", undef], ["attr3", "b", true]], 12, "hello", false]
 // EXTERNAL - 
 //    is_list(), list_insert(), list_shape(), list_pad(), list_set() (BOSL2); 
-function Object(obj_name, obj_attrs=[], vlist=[], mutate=[]) =
-    assert(is_list(obj_attrs), str(obj_name, " argument 'obj_attrs' must be a list"))
-    assert(is_list(vlist), str(obj_name, " argument 'vlist' must be a list"))
+function Object(name, attrs=[], vlist=[], mutate=[]) =
+    assert(is_list(attrs), str(name, " argument 'attrs' must be a list"))
+    assert(is_list(vlist), str(name, " argument 'vlist' must be a list"))
     let(_ = _assert_assign_if_defined(mutate, obj_is_obj(mutate), 
-        str(obj_name, " argument 'mutate' must be an Object")))
+        str(name, " argument 'mutate' must be an Object")))
     let(
         // build the TOC. The TOC ends up looking like:
         //   ["Name", ["attr1", "type1"], ["attr2", "type2"] ... ]
-        // If no type is specified in the obj_attrs or in mutate, each 
+        // If no type is specified in the attrs or in mutate, each 
         // attribute's `type` will be "undef". 
-        obj_toc = obj_build_toc(obj_name, obj_attrs, mutate),
+        obj_toc = obj_build_toc(name, attrs, mutate),
         
         // examine vlist: if it's not a consistent dimensional length at the second 
         // level, assume that `vlist` is in fact an `arglist`, and convert it thus. 
@@ -134,8 +151,10 @@ function _rec_assign_vlist_to_obj(obj, vlist) =
 
 // Function: obj_is_obj()
 // Synopsis: Test to see if a given value could be an Object
+// Usage:
+//   bool = obj_is_obj(obj);
 // Description: 
-//   Given a thing, returns true if that thing can be considered an Object, of any type. 
+//   Given a thing, possibly an Object, returns true if that thing can be considered an Object, of any type. 
 //   .
 //   To be considered an Object, a thing must: be a list; have a zeroth element defined; 
 //   have a length that is the same length as its zeroth element; and, whose sub-list 
@@ -146,6 +165,13 @@ function _rec_assign_vlist_to_obj(obj, vlist) =
 //   obj = An Object list (potentially). No default. 
 // Continues:
 //   It is not an error to test for an object and have it return `false`. 
+// Example(NORENDER): a positive test for an Object with `obj_is_obj()`:
+//   obj = Object("Obj", ["attr=i"]);
+//   echo(obj_is_obj(obj));
+//   // emits: ECHO: true
+// Example(NORENDER): a false test for an Object:
+//   echo(obj_is_obj(1));
+//   // emits: ECHO: false
 function obj_is_obj(obj) = 
     (is_list(obj))                                          // "Object base type must be a list")
         && (_defined(obj[0]))                               // "First element in object list must be defined"
@@ -156,8 +182,10 @@ function obj_is_obj(obj) =
 
 // Function: obj_is_valid()
 // Synopsis: Deeply test an Object to ensure its data types are consistent
+// Usage:
+//   bool = obj_is_valid(obj);
 // Description:
-//   Given an object, returns `true` if the object is "valid", and `false` otherwise. "Valid" in this 
+//   Given an object `obj`, returns `true` if the object is "valid", and `false` otherwise. "Valid" in this 
 //   context means the object is an object (as per `obj_is_obj()`); and, has at least one attribute element; whose 
 //   attributes all have a valid type assigned; and, whose attributes with values all match their specified types. 
 // Arguments:
@@ -176,13 +204,13 @@ function obj_value_datatype_check(obj) = !in_list(false,
 
 // Function: obj_debug_obj()
 // Synopsis: Given an Object, return a single string that describes the Object 
+// Usage:
+//   string = obj_debug_obj(obj);
+//   string = obj_debug_obj(obj, <show_defaults=true>, <sub_defaults=false>);
 // Description: 
-//   Given an object, return a string of debug layout information 
+//   Given an object `obj`, return a string `string` of debug layout information 
 //   of the object. Nested objects within the object will also 
 //   be expanded with a visual indent.
-// Usage:
-//   obj_debug_obj(obj);
-//   obj_debug_obj(obj, <show_defaults=true>, <sub_defaults=false>);
 // Arguments:
 //   obj = An Object list. No default. 
 //   ---
@@ -191,7 +219,7 @@ function obj_value_datatype_check(obj) = !in_list(false,
 // Continues:
 //   `obj_debug_obj()` does not output this debugging information anywhere: it's up 
 //   to the caller to do this. 
-// Example:
+// Example(NORENDER):
 //   axle = Axle([["diameter", 10]]);
 //   echo(obj_debug_obj(axle));
 //   // yields:
@@ -251,16 +279,14 @@ function obj_debug_obj(obj, ws="", sub_defaults=false, show_defaults=true) =
 //   data type for both of the attributes. 
 //   ```openscad
 //   object = [
-//      // this first element is the TOC:
+//      // element 0: this list is the table-of-contents
 //      [
-//         ["Axle"],
-//         ["length", "i", 10],
-//         ["diameter", "i", 10]
+//         ["Axle"],                // The Object's name
+//         ["length", "i", 10],     // the 'length' attribute definition
+//         ["diameter", "i", 10]    // the 'diameter' attribute definition
 //         ], 
-//      // this is the value of the 'length' attribute:
-//      undef, 
-//      // this is the value of the 'diameter' attribute:
-//      undef
+//      undef,   // element 1: the value of the 'length' attribute, currently unset 
+//      undef    // element 2: the value of the 'diameter' attribute, currently unset 
 //      ];
 //   ``` 
 //   There are two attributes listed in the above example TOC, and there are two 
@@ -269,33 +295,33 @@ function obj_debug_obj(obj, ws="", sub_defaults=false, show_defaults=true) =
 //   .
 //   In general the functions in this section aren't really functions you'd need in your 
 //   day-to-day modeling. 
-// 
 //
 // Function: obj_build_toc()
 // Synopsis: Construct a TOC
 // Description: 
-//   Given an object name, an attribute-type set, and optionally an existing object to mutate from,
+//   Given an Object name `name`, an attribute-type set list `attrs`, and optionally an existing object to mutate from `mutate`,
 //   construct a table-of-contents (TOC) and return it. 
 // Arguments:
-//   obj_name = The "name" of the object (think "classname"), for example: `Axle`. No default. 
-//   obj_attrs = The list of known attributes and their type for this object, eg: `["length=i", "style=s", "optional_attr=[]"]`. No default. 
-//   mutate = An existing Object of a similar `obj_name` type on which to pre-set values. No default. 
-function obj_build_toc(obj_name, obj_attrs, mutate) = 
-    assert(_defined(obj_attrs) || _defined(mutate), 
-        "obj_build_toc: at least one of either obj_attrs or mutate must be provided")
+//   name = The "name" of the object (think "classname"). No default. 
+//   attrs = The list of known attributes and their type for this object, eg: `["length=i", "style=s", "optional_attr=[]"]`. No default. 
+//   ---
+//   mutate = An existing Object of a similar `name` type on which to pre-set values. No default. 
+function obj_build_toc(name, attrs, mutate) = 
+    assert(_defined(attrs) || _defined(mutate), 
+        "obj_build_toc: at least one of either attrs or mutate must be provided")
     let(
-        toc_attrs_with_type = [ for ( i=[0:len(obj_attrs) - 1] ) attr_type_default_from_string_or_pairs(obj_attrs[i]) ],
-        new_toc = list_insert(toc_attrs_with_type, [0], [obj_name])
+        toc_attrs_with_type = [ for ( i=[0:len(attrs) - 1] ) attr_type_default_from_string_or_pairs(attrs[i]) ],
+        new_toc = list_insert(toc_attrs_with_type, [0], [name])
     )
     (obj_is_obj(mutate)) ? obj_toc(mutate) : new_toc;
 
 
 // Function: obj_toc()
 // Synopsis: Get an Object's TOC
-// Description:
-//   Given an object, return that object's TOC. 
 // Usage:
 //   toc = obj_toc(obj);
+// Description:
+//   Given an object `obj`, return that object's TOC as a list `toc`. 
 // Arguments:
 //   obj = An Object list. No default. 
 function obj_toc(obj) = obj[0];
@@ -303,16 +329,16 @@ function obj_toc(obj) = obj[0];
 
 // Function: obj_toc_get_type()
 // Synopsis: Get an Object's type from its TOC
-// Description: 
-//   Given an object, return its "type" from its TOC. If there is no TOC, an error is raised. 
 // Usage:
-//   obj_toc_get_type(obj);
+//   type = obj_toc_get_type(obj);
+// Description: 
+//   Given an object, return its "type" (or "name") from its TOC. If there is no TOC, an error is raised. 
 // Arguments:
 //   obj = An Object list. No default. 
-// Example:
-//   axle = Axle([["diameter", 10]]);
-//   type = obj_toc_get_type(axle);
-//   // type == "Axle"
+// Example(NORENDER):
+//   obj = Object("ExampleObject", ["diameter=i=10"]);
+//   type = obj_toc_get_type(obj);
+//   // type == "ExampleObject"
 function obj_toc_get_type(obj) = 
     (_defined(obj[0][0])) 
         ? obj[0][0] 
@@ -321,17 +347,17 @@ function obj_toc_get_type(obj) =
 
 // Function: obj_toc_get_attributes()
 // Synopsis: Get the list of attributes
+// Usage:
+//   obj_toc_get_attributes(obj);
 // Description:
 //   Given an object, return its list of attributes. This may differ from the list of 
 //   attributes in the object's TOC, because of the TOC itself.
 //   .
 //   `obj_toc_get_attributes()` returns the TOC index as an attribute pair 
 //   of a literal "TOC", and an attribute type of `o`; should look like `["_toc_", "o"]`. 
-// Usage:
-//   obj_toc_get_attributes(obj);
 // Arguments:
 //   obj = An Object list. No default. 
-// Example:
+// Example(NORENDER):
 //   axle = Axle([]);
 //   attrs = obj_toc_get_attributes(axle);
 //   // attrs == [["_toc_", "o"], ["diameter", "i"], ["length", "i"]];
@@ -344,16 +370,16 @@ function obj_toc_get_attributes(obj) =
 
 // Function: obj_toc_get_attr_names()
 // Synopsis: Get the list of attribute names
-// Description:
-//   Given an object, return its list of attribute names. 
 // Usage:
-//   obj_toc_get_attr_names(obj);
+//   names = obj_toc_get_attr_names(obj);
+// Description:
+//   Given an object `obj`, return its attribute names as a list `names`. 
 // Arguments:
 //   obj = An Object list. No default.
-// Example:
-//   axle = Axle([]);
-//   names = obj_toc_get_attr_names(axle);
-//   // names == ["_toc_", "diameter", "length"];
+// Example(NORENDER):
+//   obj = Object("ExampleObject", ["attr1=i", "attr2=i", "attr3=i"]);
+//   names = obj_toc_get_attr_names(obj);
+//   // names == ["_toc_", "attr1", "attr2", "attr3"]
 // Todo: 
 //   honestly I'm not wild about the TOC being returned in the list of attributes. 
 function obj_toc_get_attr_names(obj) = [ for (i=obj_toc_get_attributes(obj)) i[0] ];
@@ -361,17 +387,17 @@ function obj_toc_get_attr_names(obj) = [ for (i=obj_toc_get_attributes(obj)) i[0
 
 // Function: obj_toc_get_attr_types()
 // Synopsis: Get the list of attribute types
-// Description:
-//   Given an object, return its list of attribute types. Types are 
-//   returned in the same order and index as their corresponding attributes. 
 // Usage:
-//   obj_toc_get_attr_types(obj);
+//   types = obj_toc_get_attr_types(obj);
+// Description:
+//   Given an object `obj`, return its attributes' types as a list `types`. Types are 
+//   returned in the same order and index as their corresponding attributes. 
 // Arguments:
 //   obj = An Object list. No default.
-// Example:
-//   axle = Axle([]);
-//   names = obj_toc_get_attr_types(axle);
-//   // names == ["o", "i", "i"];
+// Example(NORENDER):
+//   obj = Object("ExampleObj", ["attr1=o", "attr2=i", "attr3=i"]);
+//   types = obj_toc_get_attr_types(obj);
+//   // types == ["o", "i", "i"];
 // Todo: 
 //   honestly I'm not even really sure *when* you'd use this.
 function obj_toc_get_attr_types(obj) = [ for (i=obj_toc_get_attributes(obj)) i[1] ];
@@ -379,16 +405,17 @@ function obj_toc_get_attr_types(obj) = [ for (i=obj_toc_get_attributes(obj)) i[1
 
 // Function: obj_toc_get_attr_defaults()
 // Synopsis: Get the list of attribute default values
-// Description: 
-//   Given an object, return its list of attribute default values. Default values are 
-//   returned in the same order and index as their corresponding attribute names.
 // Usage:
-//   obj_toc_get_attr_defaults(obj);
+//   defaults = obj_toc_get_attr_defaults(obj);
+// Description: 
+//   Given an object `obj`, return its attributes' default values as a list `defaults`. 
+//   Default values are returned in the same order and index as their corresponding 
+//   attribute names.
 // Arguments:
 //   obj = An Object list. No default.
-// Example:
-//   axle = Axle([]);
-//   values = obj_toc_get_attr_defaults(axle);
+// Example(NORENDER):
+//   obj = Object("ExampleObj", ["a1=i=20", "a2=i=10"]);
+//   values = obj_toc_get_attr_defaults(obj);
 //   // values == [20, 10];
 // Todo: 
 //   confirm, clarify example
@@ -397,86 +424,86 @@ function obj_toc_get_attr_defaults(obj) = [ for (i=obj_toc_get_attributes(obj)) 
 
 // Function: obj_toc_attr_len()
 // Synopsis: Get the number of attributes in an Object
-// Description:
-//   Given an object, return the number of attributes defined for that object. 
 // Usage:
-//   length = obj_toc_attr_len(obj);
+//   num = obj_toc_attr_len(obj);
+// Description:
+//   Given an object `obj`, return the number of attributes defined for that object `num`. 
 // Arguments:
 //   obj = An Object list. No default.
 // Todo: 
-//   I'm not super wild about the TOC being considered in this length
+//   I'm not super wild about the TOC being considered in this length (wait... *is* it being considered?)
 function obj_toc_attr_len(obj) = len(obj[0]) - 1;
 
 
 // Function: obj_toc_get_attr_type_by_name()
 // Synopsis: Get a data type for a particular attribute by name
-// Description:
-//   Given an object and an attribute name, return the attribute data type 
-//   expected for that attribute. 
-//   Valid data types are listed in `ATTRIBUTE_DATA_TYPES`.
 // Usage:
 //   type = obj_toc_get_attr_type_by_name(obj, name);
+// Description:
+//   Given an object `obj` and an attribute name `name`, return the attribute data type 
+//   expected for that attribute. 
+//   Valid data types are listed in `ATTRIBUTE_DATA_TYPES`.
 // Arguments:
 //   obj = An Object list. No default. 
 //   name = The attribute name for whose data type you want. No default.
-// Example:
-//   axle = Axle();
-//   type = obj_toc_get_attr_type_by_name(axle, "diameter");
+// Example(NORENDER):
+//   obj = Object("ExampleObj", ["a1=i=10", "a2=i=10"]);
+//   type = obj_toc_get_attr_type_by_name(obj, "a1");
 //   // type == "i"
 function obj_toc_get_attr_type_by_name(obj, name) = obj_toc_get_attr_type_by_id(obj, obj_toc_attr_id_by_name(obj, name)); 
 
 
 // Function: obj_toc_get_attr_type_by_id()
 // Synopsis: Get a data type for a particular attribute by ID 
-// Description:
-//   Given an object and an attribute id, return the attribute data type 
-//   expected for that attribute. 
-//   Valid data types are listed in `ATTRIBUTE_DATA_TYPES`.
 // Usage:
 //   type = obj_toc_get_attr_type_by_id(obj, id);
+// Description:
+//   Given an object `obj` and a numerical attribute ID `id`, return the attribute data type 
+//   expected for that attribute as `type` 
+//   Valid data types are listed in `ATTRIBUTE_DATA_TYPES`.
 // Arguments:
 //   obj = An Object list. No default. 
-//   id = The attribute id for whose data type you want. No default.
-// Example:
-//   axle = Axle();
-//   type = obj_toc_get_attr_type_by_id(axle, 1);
+//   id = The attribute ID for whose data type you want. No default.
+// Example(NORENDER):
+//   obj = Object("ExampleObj", ["a1=i=10", "a2=i=10"]);
+//   type = obj_toc_get_attr_type_by_id(obj, 1);
 //   // type == "i"
 function obj_toc_get_attr_type_by_id(obj, id) = obj_toc_get_attr_types(obj)[ id ];
 
 
 // Function: obj_toc_get_attr_default_by_name()
 // Synopsis: Get an attribute's default value by name
-// Description:
-//   Given an object and an attribute name, return the attribute's default value 
-//   expected for that attribute. 
 // Usage:
-//   default_value = obj_toc_get_attr_default_by_name(obj, name);
+//   default = obj_toc_get_attr_default_by_name(obj, name);
+// Description:
+//   Given an object `obj` and an attribute name `name`, return the attribute's default value 
+//   expected for that attribute as `default`.
 // Arguments:
 //   obj = An Object list. No default.
 //   name = The attribute name for whose default value you want. No default.
-// Example:
-//   axle = Axle([]);
-//   def = obj_toc_get_attr_default_by_name(axle, "style");
-//   // def == "axle"
+// Example(NORENDER):
+//   obj = Object("ExampleObj", ["a1=i=10", "a2=i=20"]);
+//   default = obj_toc_get_attr_default_by_name(obj, "a1");
+//   // default == 10
 // Todo: 
-//   confirm, clarify example
+//   confirm example
 function obj_toc_get_attr_default_by_name(obj, name) = obj_toc_get_attr_default_by_id(obj, obj_toc_attr_id_by_name(obj, name));
 
 
 // Function: obj_toc_get_attr_default_by_id()
 // Synopsis: Get an attribute's default value by ID
-// Description:
-//   Given an object and an attribute id, return the attribute's default value
-//   expected for that attribute.
 // Usage:
-//   default_value = obj_toc_get_attr_default_by_id(obj, id);
+//   default = obj_toc_get_attr_default_by_id(obj, id);
+// Description:
+//   Given an object `obj` and a numerical attribute ID `id`, return the attribute's default value
+//   expected for that attribute as `default`.
 // Arguments:
 //   obj = An Object list. No default.
 //   id = The attribute id for whose default value you want. No default.
-// Example:
-//   axle = Axle([]);
-//   def = obj_toc_get_attr_default_by_id(axle, 4);
-//   // def == "axle"
+// Example(NORENDER):
+//   obj = Object("ExampleObj", ["a1=i=10", "a2=i=20"]);
+//   default = obj_toc_get_attr_default_by_id(obj, 2);
+//   // default == 20
 // Todo: 
 //   confirm, clarify example
 function obj_toc_get_attr_default_by_id(obj, id) = obj_toc_get_attr_defaults(obj)[ id ];
@@ -485,21 +512,25 @@ function obj_toc_get_attr_default_by_id(obj, id) = obj_toc_get_attr_defaults(obj
 // Function: obj_toc_attr_id_by_name()
 // Synopsis: Translate an attribute's name into an ID
 // Usage:
-//   obj_addr_id_by_name(object, name);
+//   id = obj_addr_id_by_name(object, name);
 // Description:
 //   Tranlate function to convert attribute names to list index in the object's attribute TOC. 
-//   Given an object with a valid TOC and a `name` argument, looks up the `name` within the TOC 
-//   and returns the expected index of the attribute within the object list. 
+//   Given an object `obj` with a valid TOC, and an attribute name `name`, looks up the `name` within the TOC 
+//   and returns the expected index number of the attribute within the object list. 
 //   .
-//   If `name` is not found within the TOC, or if no TOC is found at index `0`, an error is thrown. 
-//   .
-//   Functionally the opposite of `obj_toc_attr_id_by_name()`. 
-// Example:
+//   Functionally this is the opposite of `obj_toc_attr_id_by_name()`. 
+// Arguments:
+//   obj = An Object list. No default.
+//   name = The attribute name for whose default value you want. No default.
+// Continues:
+//   It is an error to specify a `name` that isn't present within the TOC. It is an error to specify 
+//   an Object without a valid TOC, or to pass a non-Object value as `obj` (such as a number).
+// Example(NORENDER):
 //   axle = Axle([["diameter", 10], ["length", 30]]);
 //   // axle == [["Axle", ["diameter", "i"], ["length", "i"]], 10, 30];
 //   id = obj_toc_attr_id_by_name(axle, "diameter");
 //   // id == 1
-// Example:
+// Example(NORENDER):
 //   axle = Axle([]);
 //   // axle == [["Axle", ["diameter", "i"], ["length", "i"]], undef, undef];
 //   id = obj_toc_attr_id_by_name(axle, "not-found");
@@ -526,21 +557,25 @@ function obj_toc_attr_id_by_name(obj, name) =
 // Function: obj_toc_attr_name_by_id()
 // Synopsis: Translate an attribute's ID into a name
 // Usage:
-//   obj_toc_attr_name_by_id(object, id);
+//   name = obj_toc_attr_name_by_id(object, id);
 // Description:
 //   Translate function to convert attribute IDs (indexed positions within the object list) to the object 
-//   attribute's name within the object's TOC. Given an object with a valid TOCC and an `id` argument, 
-//   returns the name at that `id` list index from the object's TOC. 
+//   attribute's name within the object's TOC. Given an object with a valid TOC `obj`, and a numerical attribute
+//   ID `id`, returns the name at that `id` list index from the object's TOC as `name`.
 //   .
-//   If `id` is not found within the TOC, or if no TOC is found at index `0`, an error is thrown. 
-//   .
-//   Functionally the opposite of `obj_toc_attr_id_by_name()`. 
-// Example:
+//   Functionally this is the opposite of `obj_toc_attr_id_by_name()`. 
+// Arguments:
+//   obj = An Object list. No default.
+//   id = The attribute id for whose default value you want. No default.
+// Continues:
+//   It is an error to specify an `id` that exceeds the attribute length within the TOC. It is an error to specify 
+//   an Object without a valid TOC, or to pass a non-Object value as `obj` (such as a number).
+// Example(NORENDER):
 //   axle = Axle([["diameter", 10], ["length", 30]]);
 //   // axle == [["Axle", "diameter", "length"], 10, 30];
 //   name = obj_toc_attr_name_by_id(axle, 1);
 //   // name == "diameter"
-// Example:
+// Example(NORENDER):
 //   axle = Axle([]);
 //   // axle == [["Axle", "diameter", "length"], undef, undef];
 //   name = obj_toc_attr_name_by_id(axle, 3);
@@ -562,48 +597,46 @@ function obj_toc_attr_name_by_id(obj, id) =
     name;
 
 
-// Function: attr_arglist_to_vlist()
-// Synopsis: Convert a single list of arguments into a vlist
-// Description:
-//   When you have an existing object and want named module arguments to 
-//   take precedence with a mutation, attr_arglist_to_vlist() simplifies that 
-//   process. Pass the arguments and their values as a flat list, and 
-//   attr_arglist_to_vlist() will return a vlist suitable for a new object. 
-// Usage:
-//   vlist = attr_arglist_to_vlist(flattened_arglist);
-//   [["length", 10], ["height", 10]] = attr_arglist_to_vlist(["length", 10, "height", 10, "wall", undef]);
-// Example:
-//   module axle(axle, length=undef, height=undef) {
-//      vlist = attr_arglist_to_vlist(["length", length, "height", height]);
-//      //  for arguments that have a value, returns `[[attr, val]]`. 
-//      localized_axle = Axle(vlist, mutate=axle);
-//      // localized_axle now has all the values of `axle`, except 
-//      // for arguments to this module that are defined. 
-//   }
-// EXTERNAL - 
-//   list_to_matrix() (BOSL2);
+/// Function: attr_arglist_to_vlist()
+/// Synopsis: Convert a single list of arguments into a vlist
+/// Usage:
+///   vlist = attr_arglist_to_vlist(flattened_arglist);
+///   [["length", 10], ["height", 10]] = attr_arglist_to_vlist(["length", 10, "height", 10, "wall", undef]);
+/// Description:
+///   When you have an existing object and want named module arguments to 
+///   take precedence with a mutation, attr_arglist_to_vlist() simplifies that 
+///   process. Pass the arguments and their values as a flat list, and 
+///   attr_arglist_to_vlist() will return a vlist suitable for a new object. 
+/// Example(NORENDER):
+///   module axle(axle, length=undef, height=undef) {
+///      vlist = attr_arglist_to_vlist(["length", length, "height", height]);
+///      //  for arguments that have a value, returns `[[attr, val]]`. 
+///      localized_axle = Axle(vlist, mutate=axle);
+///      // localized_axle now has all the values of `axle`, except 
+///      // for arguments to this module that are defined. 
+///   }
+/// EXTERNAL - 
+///   list_to_matrix() (BOSL2);
 function attr_arglist_to_vlist(list) = [ for (i=list_to_matrix(list, 2)) if (_defined(i[1])) i ];
     
 
-// Function: attr_type_default_from_string_or_pairs()
-// Synopsis: Create an identifying tuple of attribute info
-// Description:
-//   Given either a list-pair of `[attribute, type, default]`, or a string of `attribute=type=default`, 
-//   return a tuple list-pair of `[attribute, type, default]`. `attribute` should be an attribute name 
-//   for an object list under construction. If `type` is gleanable, it should be one of 
-//   types listed in `ATTRIBUTE_DATA_TYPES`. If `type` is not gleanable, it will be set to `undef`. 
-//   If a `default` is provided, it must match the `type` gleaned. 
-// Arguments:
-//   tuple = Either a string or list pair from which to construct the pairing. 
-//
-// Continues:
-//   Tuples of type `u` ("undefined") cannot have default values apart from `undef` specified. 
-//   .
-//   Tuples of type `l` ("list") or `o` ("object") can have a default value set at object creation, 
-//   however they must be defined as a list-pair and not as a string. 
-//
-// Todo:
-//   no real format or bounds checking is done on `tuple`, perhaps we should.
+/// Function: attr_type_default_from_string_or_pairs()
+/// Synopsis: Create an identifying tuple of attribute info
+/// Description:
+///   Given either a list-pair of `[attribute, type, default]`, or a string of `attribute=type=default`, 
+///   return a tuple list-pair of `[attribute, type, default]`. `attribute` should be an attribute name 
+///   for an object list under construction. If `type` is gleanable, it should be one of 
+///   types listed in `ATTRIBUTE_DATA_TYPES`. If `type` is not gleanable, it will be set to `undef`. 
+///   If a `default` is provided, it must match the `type` gleaned. 
+/// Arguments:
+///   tuple = Either a string or list pair from which to construct the pairing. 
+/// Continues:
+///   Tuples of type `u` ("undefined") cannot have default values apart from `undef` specified. 
+///   .
+///   Tuples of type `l` ("list") or `o` ("object") can have a default value set at object creation, 
+///   however they must be defined as a list-pair and not as a string. 
+/// Todo:
+///   no real format or bounds checking is done on `tuple`, perhaps we should.
 function attr_type_default_from_string_or_pairs(tuple) = 
     let(
         elems = (is_list(tuple)) ? tuple : str_split(tuple, "="),
@@ -657,38 +690,113 @@ function _attr_type_default_from_string_recast(type, value_as_string) =
     ) v;
 
 
+// Subsection: Basic Object Usage
+//
+// Function: obj_has()
+// Synopsis: Test to see if an Object has a particular attribute
+// Usage:
+//   bool = obj_has(obj, name);
+// Description:
+//   Given an object `obj` and an accessor name `name`, return `true` if the object "can" access 
+//   that name, or `false` otherwise. An object need not have a specified value for the given name, 
+//   only the ability to access and refer to it; in other words, if the `name` exists in the Object's 
+//   TOC, then `obj_has()` will return true. 
+//   .
+//   Essentially, this is a thinly wrapped `obj_toc_get_attr_names()`.
+//   .
+//   This might seem similar way to perl5's `can()` or python's `callable()`, but this is inaccurate: 
+//   `obj_has()` cannot test if the object is able to execute or call the given `name`; it can only 
+//   tell if the object has the given `name` as an attribute. The perl5 `exists()` or python `hasattr()` 
+//   functions would be more analagous to `obj_has()`. 
+// Arguments:
+//   obj = An Object list. No default.
+//   name = A string that may exist as an attribute for the Object. No default.
+// Example(NORENDER):
+//   obj = Object("ExampleObj", ["a1=i=10", "a2=i", "a3=i=13"], ["a1", 10, "a2", 12, "a3", 23]);
+//   b = obj_has(obj, "a1");
+//   // b == true
+// Example(NORENDER):
+//   obj = Object("ExampleObj", ["a1=i=10", "a2=i", "a3=i=13"], ["a1", 10, "a2", 12, "a3", 23]);
+//   b = obj_has(obj, "radius");
+//   // b == false
+function obj_has(obj, name) = in_list(name, obj_toc_get_attr_names(obj));
+
+
+// Function: obj_has_value()
+// Synopsis: Test to see if an Object has any data in it
+// Usage:
+//   bool = obj_has_value(obj);
+// Description:
+//   Given an object `obj`, return `true` if any one of its attributes are defined. If no attributes 
+//   have a value defined, `obj_has_value()` returns `false`. 
+//   .
+//   `obj_has_value()` does not evaluate the values of an object using any accessors, there is no 
+//   conditional evaluation of the values done: objects that provide accessors with defaults 
+//   won't use those accessors here, and unset attribute values will be considered undefined. 
+// Arguments:
+//   obj = An Object list. No default. 
+// Example(NORENDER):
+//   obj = Object("ExampleObj", ["a1=i=10", "a2=i", "a3=i=13"], ["a1", 10, "a2", 12, "a3", 23]);
+//   retr = obj_has_value(obj);
+//   // retr == `true`
+// Example(NORENDER):
+//   obj = Object("ExampleObj", ["a1=i=10", "a2=i", "a3=i=13"]);
+//   retr = obj_has_value(obj);
+//   // retr == `false`
+function obj_has_value(obj) = (_defined_len(obj_get_values(obj)) > 0) ? true : false;
+
+
+// Function: obj_get_names()
+// Synopsis: Get a list of all the attribute names in the Object
+// Usage:
+//   names = obj_get_names(obj);
+// Description:
+//   Given an object `obj`, return the names of the attributes listed in its TOC as a 
+//   list `names`. Names are returned in the order in which they are stored in the Object.
+//   .
+//   `obj_get_names()` does not return the Object's TOC.
+// Arguments:
+//   obj = An Object list. No default. 
+// Example(NORENDER):
+//   obj = Object("ExampleObj", ["a1=i", "a2=i", "a3=i"], ["a1", 10, "a2", 12, "a3", 23]);
+//   names = obj_get_names(obj);
+//   // names == ["a1", "a2", "a3"];
+function obj_get_names(obj) = slice(obj_toc_get_attr_names(obj), 1);
+
+
 // Function: obj_get_values()
 // Synopsis: Get a list of all the values in the Object
+// Usage:
+//   values = obj_get_values(obj);
 // Description:
-//   Given an object, return the values of the attributes listed in its 
-//   TOC, as a list. This is functionally the same as doing `[for (i=[1:len(obj[0])-1]) obj[i]]`.
-//   Values are returned in the order in which they're stored in the object. 
+//   Given an object `obj`, return the values of the attributes listed in its 
+//   TOC as a list `values`. This is functionally the same as doing `[for (i=[1:len(obj[0])-1]) obj[i]]`.
+//   Values are returned in the order in which they are stored in the object. 
 //   .
 //   `obj_get_values()` does not return the object's TOC, so `len(object) > len(obj_get_values(object))`. 
 //   .
 //   `obj_get_values()` does not return values via the built-in accessor `obj_accessor()`, and no 
 //   value defaults or type checking is done on the values before they're returned. 
-// Usage:
-//   obj_get_values(obj);
 // Arguments:
 //   obj = An Object list. No default. 
-// Example:
-//   axle = Axle([["diameter", 5], ["length", 10]]);
-//   values = obj_get_values(axle);
-//   // values == [5, 10];
+// Example(NORENDER):
+//   obj = Object("ExampleObj", ["a1=i", "a2=i", "a3=i"], ["a1", 10, "a2", 12, "a3", 23]);
+//   values = obj_get_values(obj);
+//   // values == [10, 12, 23];
+/// NOTE: Resist the urge to change `obj_get_values()` to use a wrapped accessor without reexamining `obj_has_value()`
 function obj_get_values(obj) = slice(obj, 1);
 
 
 // Function: obj_get_values_by_attrs()
 // Synopsis: Get a list of values from the Object in arbitrary order
+// Usage:
+//   values = obj_get_values_by_attrs(obj, names);
 // Description:
 //   Given an object `obj` and a list of attribute names `names`, return the values for those 
 //   attributes as a list `values`. Values are returned in the order in which they are 
 //   specified in `names`. 
 //   If the attributes have no value set, and there is a list of optional defaults `defaults`, 
 //   returns the value at the same position as the attribute appears in `names`. 
-// Usage:
-//   values = obj_get_values_by_attrs(obj, names);
 // Arguments:
 //   obj = An Object list. No default. 
 //   names = A list of attribute names. No default.
@@ -733,59 +841,22 @@ function obj_get_values_by_attrs(obj, names, defaults=[]) =
     [ for (i=idx(names)) obj_accessor_get(obj, names[i], default=_defaults[i]) ];
 
 
-
-// Function: obj_has_value()
-// Synopsis: Test to see if an Object has any data in it
-// Description:
-//   Given an object, return `true` if any one of its attributes are defined. If no attributes 
-//   have a value defined, `obj_has_value()` returns `false`. 
-//   .
-//   Note: `obj_has_value()` does not evaluate the values of an object using any accessors, there is no 
-//   conditional evaluation of the values done: objects that provide accessors with defaults 
-//   won't use those accessors here, and unset attribute values will be considered undefined. 
+// Function: obj_get_defaults()
+// Synopsis: Get a list of all the attribute defaults in the Object
 // Usage:
-//   obj_has_value(obj);
+//   defaults = obj_get_defaults(obj);
+// Description:
+//   Given an Object `obj`, return the defaults values of the attributes listed in its
+//   TOC as a list `defaults`. Defaults are returned in the order in which they are 
+//   stored in the Object. If an attribute has no default set, its position in the 
+//   `defaults` list will be `undef`.
 // Arguments:
 //   obj = An Object list. No default. 
-// Example:
-//   axle = Axle([]);
-//   retr = obj_has_value(axle);
-//   // retr is `false`
-// Example:
-//   axle = Axle([["length", 20]]);
-//   retr = obj_has_value(axle);
-//   // retr is `true`
-function obj_has_value(obj) = (_defined_len(obj_get_values(obj)) > 0) ? true : false;
-
-
-// Function: obj_has()
-// Synopsis: Test to see if an Object has a particular attribute
-// Description:
-//   Given an object `obj` and an accessor name `name`, return `true` if the object "can" access 
-//   that name, or `false` otherwise. An object need not have a specified value for the given name, 
-//   only the ability to access and refer to it; in other words, if the `name` exists in the Object's 
-//   TOC, then `obj_has()` will return true. 
-//   .
-//   Essentially, this is a thinly wrapped `obj_toc_get_attr_names()`.
-//   .
-//   This might seem similar way to perl5's `can()` or python's `callable()`, but this is inaccurate: 
-//   `obj_has()` cannot test if the object is able to execute or call the given `name`; it can only 
-//   tell if the object has the given `name` as an attribute. The perl5 `exists()` or python `hasattr()` 
-//   functions would be more analagous to `obj_has()`. 
-// Usage:
-//   bool = obj_has(obj, name);
-// Arguments:
-//   obj = An Object list. No default.
-//   name = A string that may exist as an attribute for the Object. No default.
-// Example:
-//   axle = Axle([["diameter", 10], ["length", 30]]);
-//   b = obj_has(axle, "diameter");
-//   // b == true
-// Example:
-//   axle = Axle([["diameter", 10], ["length", 30]]);
-//   b = obj_has(axle, "radius");
-//   // b == false
-function obj_has(obj, name) = in_list(name, obj_toc_get_attr_names(obj));
+// Example(NORENDER):
+//   obj = Object("ExampleObj", ["a1=i=10", "a2=i", "a3=i=13"], ["a1", 10, "a2", 12, "a3", 23]);
+//   defaults = obj_get_names(obj);
+//   // defaults == [10, undef, 13];
+function obj_get_defaults(obj) = obj_toc_get_attr_defaults(obj);
 
 
 // Subsection: Object Base Accessors
@@ -830,6 +901,13 @@ function obj_has(obj, name) = in_list(name, obj_toc_get_attr_names(obj));
 //
 // Function: obj_accessor()
 // Synopsis: Generic read/write attribute accessor
+// Usage:
+//   obj_accessor(obj, name, <default=undef>, <nv=undef>);
+// Usage: to retrieve an attribute's value from an object:
+//   value = obj_accessor(obj, name);
+//   value = obj_accessor(obj, name, <default=undef>);
+// Usage: to set an attribute's value into an object:
+//   new_object = obj_accessor(obj, name, nv=new_value);
 // Description:
 //   Basic accessor for object attributes. Given an object `obj` and an attribute name `name`, operates on that attribute. 
 //   The operation depends on what other options are passed. Calls to `obj_accessor()` with an `nv` (new-value) option 
@@ -842,15 +920,6 @@ function obj_has(obj, name) = in_list(name, obj_toc_get_attr_names(obj));
 //   if the value of `name` in the object is not defined, the value of the `default` option passed to `obj_accessor()`
 //   will be returned; if there is no `default` option provided, the object's TOC default will be returned; if there is no TOC default
 //   for the object, `undef` will be returned. 
-//   
-// Usage:
-//   obj_accessor(obj, name, <default=undef>, <nv=undef>);
-// Usage: to retrieve an attribute's value from an object:
-//   value = obj_accessor(obj, name);
-//   value = obj_accessor(obj, name, <default=undef>);
-// Usage: to set an attribute's value into an object:
-//   new_object = obj_accessor(obj, name, nv=new_value);
-//
 // Arguments:
 //   obj = An Object list. No default. 
 //   name = The attribute name to access. The name must be present in `obj`'s TOC. No default. 
@@ -858,7 +927,6 @@ function obj_has(obj, name) = in_list(name, obj_toc_get_attr_names(obj));
 //   default = If provided, and if there is no existing value for `name` in the object `obj`, returns the value of `default` instead. 
 //   nv = If provided, `obj_accessor()` will update the value of the `name` attribute and return a new Object list. *The existing Object list is unmodified.*
 //   _consider_toc_default_values = If enabled, TOC-stored defaults will be returned according to the mechanics above. If disabled with `false`, the TOC default for a given attribute will not be considered as a viable return value. Default: `true`
-//
 // Continues:
 //   It's not an error to provide both `default` and `nv` in the same request, but doing so will yield a warning 
 //   nonetheless. If they're both present, `obj_accessor()` will act on the new value in `nv` and return a new object 
@@ -869,34 +937,29 @@ function obj_has(obj, name) = in_list(name, obj_toc_get_attr_names(obj));
 //   won't know what you meant to do and will act as if you wanted to "get" the value for that attribute. To explicitly 
 //   clear an object's attribute, use `obj_accessor_unset()`. To explicitly set an attribute to a new value, use 
 //   `obj_accessor_set()` (which will error out if `nv` is not defined). 
-//
-// Example: direct "get" call to `obj_accessor()`:
+// Example(NORENDER): direct "get" call to `obj_accessor()`:
 //   axle = Axle(["length", 30]);
 //   length = obj_accessor(axle, "length");
 //   // length == 30
 //   diameter = obj_accessor(axle, "diameter", default=10);
 //   // diameter == 10
 //   // (diameter is unset in the `axle` object, so the default of 10 is returned instead)
-//
-// Example: direct "set" calls to `obj_accessor()`:
+// Example(NORENDER): direct "set" calls to `obj_accessor()`:
 //   axle = Axle(["length", 30]);
 //   new_axle = obj_accessor(axle, "length", nv=6);
 //   // new_axle's `length` value is now 6. 
 //   // axle's `length` value is still 30.
-//
-// Example: gotcha when providing `undef` as a new-value:
+// Example(NORENDER): gotcha when providing `undef` as a new-value:
 //   axle = Axle([["diameter", 10], ["length", 30]]);
 //   new_axle = obj_accessor(axle, "length", nv=undef);
 //   // new_axle == 6, because obj_accessor() didn't see a value for `nv`, and instead of changing "length", its value was returned
-//
-// Example: providing a class-specific "glue" accessor:
+// Example(NORENDER): providing a class-specific "glue" accessor:
 //   function axle_acc(axle, name, default=undef, nv=undef) = obj_accesor(axle, name, default, nv);
 //   // ..
 //   axle = Axle([["diameter", 10], ["length", 30]]);
 //   dia = axle_acc(axle, "diameter");
 //   // dia == 10
-//
-// Example: providing a class- and attribute-specific "glue" accessor:
+// Example(NORENDER): providing a class- and attribute-specific "glue" accessor:
 //   function axle_diameter(axle, default=undef, nv=undef) = obj_accessor(axle, "diameter", default=default, nv=nv);
 //   // ...
 //   axle = Axle([["diameter", 10], ["length", 30]]);
@@ -946,6 +1009,8 @@ function obj_accessor(obj, name, default=undef, nv=undef, _consider_toc_default_
 
 // Function: obj_accessor_get()
 // Synopsis: Generic read-only attribute accessor
+// Usage:
+//   value = obj_accessor_get(obj, name, <default=undef>);
 // Description:
 //   Basic "get" accessor for Objects. Given an object `obj` and attribute name `name`, `obj_accessor_get()` will look the current 
 //   value of `name` up in the object and return it (a "get" operation). 
@@ -956,35 +1021,26 @@ function obj_accessor(obj, name, default=undef, nv=undef, _consider_toc_default_
 //   if the value of `name` in the object is not defined, the value of the `default` option passed to `obj_accessor_get()`
 //   will be returned; if there is no `default` option provided, the object's TOC default will be returned; if there is no TOC default
 //   for the object, `undef` will be returned. 
-//
-// Usage:
-//   value = obj_accessor_get(obj, name, <default=undef>);
-//
 // Arguments:
 //   obj = An Object list. No default. 
 //   name = The attribute name to access. The name must be present in `obj`'s TOC.
 //   ---
 //   default = If provided, and if there is no existing value for `name` in the object `obj`, returns the value of `default` instead. 
 //   _consider_toc_default_values = If enabled, TOC-stored defaults will be returned according to the mechanics above. If disabled with `false`, the TOC default for a given attribute will not be considered as a viable return value. Default: `true`
-//
 // Continues:
 //   Note that `obj_accessor_get()` will accept a `nv` option, to make writing accessor glue easier, but 
 //   that `nv` option won't be evaluated or used. 
-//
-// Example: direct calls to `obj_accessor_get()`:
+// Example(NORENDER): direct calls to `obj_accessor_get()`:
 //   length = obj_accessor_get(axle, "length");
-//
-// Example: passing `nv` yields no change:
+// Example(NORENDER): passing `nv` yields no change:
 //   retr = obj_accessor_get(axle, "length", nv=25);
 //   // retr == 30 (or, whatever the Axle's `length` previously was; the `nv` option is ignored)
-//
-// Example: providing a class- and attribute-specific "glue" read-only accessor:
+// Example(NORENDER): providing a class- and attribute-specific "glue" read-only accessor:
 //   function get_axle_length(axle, default=undef) = obj_accesor_get(axle, "length", default=default);
 //   // ..
 //   axle = Axle([["diameter", 10], ["length", 30]]);
 //   length = get_axle_length(axle);
 //   // length == 30
-//
 function obj_accessor_get(obj, name, nv=undef, default=undef, _consider_toc_default_values=true) = 
     let(
         _ = (_defined(nv))
@@ -999,6 +1055,8 @@ function obj_accessor_get(obj, name, nv=undef, default=undef, _consider_toc_defa
 
 // Function: obj_accessor_set()
 // Synopsis: Generic write-only attribute accessor
+// Usage:
+//   new_obj = obj_accessor_set(obj, name, nv);
 // Description:
 //   Basic "set" accessor for Objects. Given an object `obj`, an attribute name `name`, and a new value `nv` for that 
 //   attribute, `obj_accessor_set()` will return a new Object list with the updated value for that attribute. 
@@ -1006,31 +1064,23 @@ function obj_accessor_get(obj, name, nv=undef, default=undef, _consider_toc_defa
 //   .
 //   It is an error to call `obj_accessor_set()` without a new value (`nv`) passed. If the value of the attribute `name` 
 //   needs to be removed, use `obj_accessor_unset()` instead. 
-//
-// Usage:
-//   new_obj = obj_accessor_set(obj, name, nv);
-//
 // Arguments:
 //   obj = An Object list. No default. 
 //   name = The attribute name to access. The name must be present in `obj`'s TOC.
 //   nv = If provided, `obj_accessor_set()` will update the value of the `name` attribute and return a new Object list. *The existing Object list is unmodified.*
-//
 // Continues:
 //   Note that `obj_accessor_set()` will accept a `default` option, to make writing accessor 
 //   glue easier, but it won't be evaluated or used. 
-//
-// Example: direct call to `obj_accessor_set()`
+// Example(NORENDER): direct call to `obj_accessor_set()`
 //   new_axle = obj_accessor_set(axle, "length", nv=20);
 //   // new_axle's `length` attribute is now 20
-//
-// Example: providing a class- and attribute-specific "glue" write-only accessor:
+// Example(NORENDER): providing a class- and attribute-specific "glue" write-only accessor:
 //   function set_axle_length(axle, nv) = obj_accessor_set(axle, "length", nv);
 //   // ..
 //   axle = Axle([["diameter", 10], ["length", 30]]);
 //   new_axle = set_axle_length(axle, 40);
 //   // new_axle == [["Axle", "diameter", "length"], 10, 40];
-//
-// Example: gotchas when setting undefined values with `obj_accessor()`:
+// Example(NORENDER): gotchas when setting undefined values with `obj_accessor()`:
 //   // Setting no value in `nv` will *not* do what you want!
 //   function set_axle_length(axle, nv=undef) = obj_accessor(axle, "length", nv);
 //   axle = Axle([["diameter", 10], ["length", 30]]);
@@ -1038,7 +1088,6 @@ function obj_accessor_get(obj, name, nv=undef, default=undef, _consider_toc_defa
 //   // new_axle == 30  //<--- This is the `length` value, NOT a new object. 
 //   // Because the `nv` option wasn't provided, the call arrived into `obj_accessor()` as `undef`, and 
 //   // was treated as a "get". 
-//
 function obj_accessor_set(obj, name, nv, default=undef) = 
     assert(_defined(name), str("obj_accessor_set(): attribute name must ",
         "be provided; called with: ", name))
@@ -1057,26 +1106,21 @@ function obj_accessor_set(obj, name, nv, default=undef) =
 
 // Function: obj_accessor_unset()
 // Synopsis: Generic attribute deleter
+// Usage:
+//   new_obj = obj_accessor_unset(obj, name);
 // Description:
 //   Basic "delete" accessor for Objects. A new Object will be returned 
 //   with the un-set attribute value. **The existing Object list is unmodified,** and a 
 //   wholly new Object list with the unset value is returned instead. 
-//
-// Usage:
-//   new_obj = obj_accessor_unset(obj, name);
-//
 // Arguments:
 //   obj = An Object list. No default. 
 //   name = The attribute name to access. The name must be present in `obj`'s TOC.
-//
-// Example:
+// Example(NORENDER):
 //   axle = Axle([["diameter", 10], ["length", 30]]);
 //   new_axle = obj_accessor_unset(axle, "length");
 //   // new_axle == [["Axle", "diameter", "length"], 10, undef];
-//
 // EXTERNAL - 
 //   list_set() (BOSL2);
-//
 function obj_accessor_unset(obj, name) = 
     list_set(obj, obj_toc_attr_id_by_name(obj, name), undef);
 
@@ -1086,29 +1130,23 @@ function obj_accessor_unset(obj, name) =
 //   standard list manipulation functions work fine, but when you need to select or act
 //   on a subset of Objects based on their attribute values, turn here.
 //
-//
 // Function: obj_select()
 // Synopsis: Select Objects from a list based on their position in that list
 // Usage:
 //   list = obj_select(obj_list, idxs);
-//
 // Description:
 //   Given a list of objects `obj_list` and a list of element indexes `idxs`, returns the
 //   objects in `obj_list` identified by their index position `idx`.
 //   .
 //   The Objects need not be all of the same object type.
-//
 // Arguments:
 //   obj_list = A list of Objects
 //   idxs = A list of positional index integers
-//
 // Continues:
 //   It's probably a really bad idea to give a list of `idxs` that doesn't match the
 //   length of `obj_list`.
-//
 // Todo:
 //   turns out this is just a very thinly wrapped select(). Is there a reason to keep this?
-//
 function obj_select(obj_list, idxs) =
     [ for (i=idxs) obj_list[i] ];
     //select(obj_list, idxs);
@@ -1118,7 +1156,6 @@ function obj_select(obj_list, idxs) =
 // Synopsis: Select Objects from a list if they have a particular attribute defined
 // Usage:
 //   list = obj_select_by_attr_defined(obj_list, attr);
-//
 // Description:
 //   Given a list of Objects `obj_list` and an attribute name `attr`, return a list of
 //   all the Objects in `obj_list` that have the attribute `attr` defined.
@@ -1127,11 +1164,9 @@ function obj_select(obj_list, idxs) =
 //   list `list` may have no elements in it.
 //   .
 //   The list of Objects need not be all of the same type.
-//
 // Arguments:
 //   obj_list = A list of Objects
 //   attr = An attribute name
-//
 function obj_select_by_attr_defined(obj_list, attr) =
     list_remove_values(
         [ for (obj=obj_list) (obj_has(obj, attr) && _defined( obj_accessor_get(obj, attr))) ? obj : undef ],
@@ -1149,12 +1184,10 @@ function obj_select_by_attr_defined(obj_list, attr) =
 //   The Objects are returned in the order they appear in `obj_list`.
 //   .
 //   The Objects in `obj_list` need not be all of the same type.
-//
 // Arguments:
 //   obj_list = A list of Objects
 //   attr = An attribute name
 //   value = A comparison value
-//
 function obj_select_by_attr_value(obj_list, attr, value) =
     let( reduced_obj_list = obj_select_by_attr_defined(obj_list, attr) )
     list_remove_values(
@@ -1172,11 +1205,9 @@ function obj_select_by_attr_value(obj_list, attr, value) =
 //   of objects by the value of their attribute `attr` and return that list.
 //   .
 //   Objects listed in `obj_list` need not be all of the same type.
-//
 // Arguments:
 //   obj_list = A list of Objects
 //   attr = An attribute name
-//
 function obj_sort_by_attribute(obj_list, attr) =
     let(
         value_list = obj_select_values_from_obj_list(obj_list, attr),
@@ -1199,13 +1230,11 @@ function obj_sort_by_attribute(obj_list, attr) =
 //   values are returned in the order they appear in `obj_list`.
 //   .
 //   The Objects in `obj_list` need not be all the same type.
-//
 // Arguments:
 //   obj_list = A list of Objects
 //   attr = An attribute name
 //   ---
 //   default = A value to be used as a default for Objects that do not have their attribute `attr` set. Default: `undef`
-//
 function obj_select_values_from_obj_list(obj_list, attr, default=undef) =
     [ for (obj=obj_list) (obj_has(obj, attr)) 
         ? obj_accessor_get(obj, attr, default=default) 
@@ -1216,7 +1245,6 @@ function obj_select_values_from_obj_list(obj_list, attr, default=undef) =
 // Synopsis: Group a list of Objects based on a specified attribute
 // Usage:
 //   list = obj_regroup_list_by_attr(obj_list, attr);
-//
 // Description:
 //   Given a list of Objects `obj_list` and an attribute name `attr`, 
 //   return a list of groups of the Objects in `obj_list` grouped
@@ -1225,11 +1253,9 @@ function obj_select_values_from_obj_list(obj_list, attr, default=undef) =
 //   The groupings of Objects are returned in no particular order. 
 //   .
 //   Objects listed in `obj_list` need not be all of the same type.
-//
 // Arguments:
 //   obj_list = A list of Objects
 //   attr = An attribute name
-//
 // Continues:
 //   If an Object within `obj_list` has the attribute `attr` but 
 //   it is neither defined nor has a default value, it will not 
@@ -1237,7 +1263,6 @@ function obj_select_values_from_obj_list(obj_list, attr, default=undef) =
 //   attribute is something that'd be *nice*; however, the 
 //   functions `obj_regroup_list_by_attr()` depends on do not 
 //   today support selecting Objects on an undefined attribute.
-//
 function obj_regroup_list_by_attr(obj_list, attr) = 
     let(
         unique_attrs = unique(
@@ -1254,7 +1279,6 @@ function obj_regroup_list_by_attr(obj_list, attr) =
 // Synopsis: Select Objects from a list based on one or more sets of attribute-value pairs
 // Usage:
 //   list = obj_select_by_attrs_values(obj_list, arglist);
-//
 // Description:
 //   Given a list of Objects `obj_list` and a list of selectors `arglist`, 
 //   recursively examine `obj_list` to select items that match each selector, and 
@@ -1274,11 +1298,9 @@ function obj_regroup_list_by_attr(obj_list, attr) =
 //   .
 //   The Objects in `obj_list` need not be all the same type, however they all 
 //   need to support the `arglist` selectors.
-//
 // Arguments:
 //   obj_list = A list of Objects
 //   arglist = A list of `[attr, value]` lists, where: `attr` is an attribute name; and, `value` is a comparison value
-//
 // See also: obj_select_by_attr_value()
 function obj_select_by_attrs_values(obj_list, arglist) = _rec_obj_select_by_attrs_values(obj_list, arglist);
 
@@ -1324,7 +1346,6 @@ function _rec_obj_select_by_attrs_values(obj_list, arglist, _id=0, _max=undef) =
 //   Object, and return their output as a list. 
 // Arguments:
 //   obj_list = A list of Objects
-//
 function obj_list_debug_obj(obj_list) = [ for (obj=obj_list) obj_debug_obj(obj) ];
 
 
@@ -1414,17 +1435,17 @@ function _type_check_value(type_id, value) =
 //   The remainder of the functions that this LibFile relies on are present in 
 //   BOSL2, all from the set of functions that make managing lists in OpenSCAD easier. They are:
 //   `flatten()`, `in_list()`, `list_insert()`, `list_pad()`, `list_set()`, `list_shape()`, and `list_to_matrix()`.
-// 
+//
 // Function: _defined()
 // Synopsis: Good all-purpose "is this variable defined?" function
+// Usage:
+//   _defined(value);
 // Description:
 //   Given a variable, return true if the variable is defined. 
 //   This doesn't differenate `true` vs `false` - `false` is still defined. 
 //   `_defined()` tests to see if a string value is something other than `undef`, 
 //   or a list value is something other than `[]` (an empty list). 
 //   *Mnem: this tests if the var has a value.*
-// Usage: 
-//   _defined(value);
 // Arguments:
 //   value = The thing to test definition.
 // Example(NORENDER):
@@ -1441,14 +1462,14 @@ function _defined(a) = (is_list(a)) ? len(a) > 0 : !is_undef(a);
 
 // Function: _first()
 // Synopsis: Return the first "defined" value in a list
+// Usage:
+//   _first(list);
 // Description:
 //   Given a list of values, returns the first defined (as per `_defined()`) in the list.
 //   Because we're using `_defined()` to test each value in the list, 
 //   `false` is a valid candidate for return. 
 //   .
 //   If there's no suitable element that can be returned, `_first()` returns undef.  
-// Usage:
-//   _first(list);
 // Arguments:
 //   list = The list from which to examine for the first defined item. `list` can be comprised of any variable type that is testable by `_defined()`. 
 // Example(NORENDER):
@@ -1463,11 +1484,11 @@ function _first(list) = [for (i = list) if (_defined(i)) i][0];
 
 // Function: _defined_len()
 // Synopsis: Return the number of defined elements in a list
+// Usage:
+//   _defined_len(list);
 // Description:
 //   Given a list of values, returns the number of defined elements in that 
 //   list. If there are no elements, or if all elements are undefined, returns `0`.
-// Usage:
-//   _defined_len(list);
 // Arguments:
 //   list = A list of items to count. `list` can be comprised of any variable type that is testable by `_defined()`. 
 // Example(NORENDER):

--- a/object_common_functions.scad
+++ b/object_common_functions.scad
@@ -88,7 +88,7 @@ include <BOSL2/std.scad>
 //   name = The "name" of the object (think "classname"). No default. 
 //   attrs = The list of known attributes, and optionally their type and default for this object. No default. 
 //   ---
-//   vlist = Variable list of attributes and values: `[ ["length", 10], ["style", "none"] ]`; **or,** a list of running attribute value pairing: `["length", 10, "style", "none"]`. Default: `[]` (which will produce an Object with no values).
+//   vlist = Variable list of attributes and values: `[ ["a1", 10], ["a2", "none"] ]`; **or,** a list of running attribute value pairing: `["a1", 10, "a2", "none"]`. Default: `[]` (which will produce an Object with no values).
 //   mutate = An existing Object of a similar `name` type on which to pre-set values. Default: `[]`
 // Continues:
 //   `Object()` returns a list that should be treated as an opaque object: reading values directly 

--- a/object_common_functions.scad
+++ b/object_common_functions.scad
@@ -445,30 +445,22 @@ function obj_get_values(obj) = slice(obj, 1);
 //   .
 //   There is no type comparison for the `defaults` list given to `obj_get_values_by_attrs()`
 //   against the attributes in `obj`.
-// Example(NORENDER):
-//   Axle_attributes = ["diameter=i", "length=i"];
-//   function Axle(vlist=[], mutate=[]) = Object("Axle", Axle_attributes, vlist, mutate);
-//   axle = Axle([["diameter", 5], ["length", 10]]);
-//   values = obj_get_values_by_attrs(axle, ["length", "diameter"]);
+// Example(NORENDER): calling `obj_get_values_by_attrs()`. Note the order of the `names` differs from the Object's order:
+//   obj = Object("ExampleObj", ["attr1=i", "attr2=i"], ["attr1", 5, "attr2", 10]);
+//   values = obj_get_values_by_attrs(obj, ["attr2", "attr1"]);
 //   // values == [10, 5]
 // Example(NORENDER): only one attribute is specified in `names`, and only one value is returned in `values`:
-//   Axle_attributes = ["diameter=i", "length=i"];
-//   function Axle(vlist=[], mutate=[]) = Object("Axle", Axle_attributes, vlist, mutate);
-//   axle = Axle([["diameter", 5], ["length", 10]]);
-//   values = obj_get_values_by_attrs(axle, ["length"]);
+//   obj = Object("ExampleObj", ["attr1=i", "attr2=i"], ["attr1", 5, "attr2", 10]);
+//   values = obj_get_values_by_attrs(obj, ["attr2"]);
 //   // values == [10]
-// Example(NORENDER): with no values set in the object, no value is returned for the attributes:
-//   Axle_attributes = ["diameter=i=5", "length=i=20"];
-//   function Axle(vlist=[], mutate=[]) = Object("Axle", Axle_attributes, vlist, mutate);
-//   axle = Axle();
-//   values = obj_get_values_by_attrs(axle, ["length", "diameter"]);
+// Example(NORENDER): with no values set in the object, `undef` is returned for the attributes:
+//   obj = Object("ExampleObj", ["attr1=i", "attr2=i"]);
+//   values = obj_get_values_by_attrs(obj, ["attr1", "attr2"]);
 //   // values == [undef, undef]
-// Example(NORENDER): with no value set in the object for "length", the value from `defaults` is returned instead:
-//   Axle_attributes = ["diameter=i=5", "length=i=20"];
-//   function Axle(vlist=[], mutate=[]) = Object("Axle", Axle_attributes, vlist, mutate);
-//   axle = Axle(["diameter", 3);
-//   values = obj_get_values_by_attrs(axle, ["length", "diameter"], defaults=[12, 12]);
-//   // values == [12, 3]
+// Example(NORENDER): with no value set in the object for "attr2" and no attribute defaults set in the Object, the value from `defaults` is returned instead:
+//   obj = Object("ExampleObj", ["attr1=i, "attr2=i"], ["attr1", 3]);
+//   values = obj_get_values_by_attrs(obj, ["attr1", "attr2"], [4, 4]);
+//   // values == [3, 4]
 function obj_get_values_by_attrs(obj, names, defaults=[]) =
     let(
         _defaults = list_pad(defaults, len(names), undef)

--- a/object_common_functions.scad
+++ b/object_common_functions.scad
@@ -93,28 +93,63 @@ include <BOSL2/std.scad>
 // Continues:
 //   `Object()` returns a list that should be treated as an opaque object: reading values directly 
 //   from the `object` list, or modifying them manually into a new list, is not entirely safe.
-// Example(NORENDER): empty object creation:
+// Example(NORENDER): empty object creation: this is an empty object that has no values assigned to its attributes:
 //   obj = Object("Obj", ["attr1=i", "attr2=s", "attr3=b=true"]);
 //   echo(obj);
 //   // emits: ECHO: [["Obj", ["attr1", "i", undef], ["attr2", "s", undef], ["attr3", "b", true]], undef, undef, undef]
-// Example(NORENDER): pre-populating object attributes at creation: 
+// Example(NORENDER): same empty object creation, but with the object shown with `obj_debug_obj()`. Note that while `attr3` has a default value set, all of the attributes are still undefined:
+//   obj = Object("Obj", ["attr1=i", "attr2=s", "attr3=b=true"]);
+//   echo(obj_debug_obj(obj));
+//   // emits: ECHO: "0: _toc_: Obj
+//   // 1: attr1 (i: undef): undef
+//   // 2: attr2 (s: undef): undef
+//   // 3: attr3 (b: true): undef"
+// Example(NORENDER): pre-populating object attributes at creation. Note the values set for `attr2` and `attr3`:
 //   o = Object("Obj", ["attr1=i", "attr2=s", "attr3=b=true"], [["attr2", "hello"], ["attr3", false]]);
-//   echo(o);
-//   // emits: ECHO: [["Obj", ["attr1", "i", undef], ["attr2", "s", undef], ["attr3", "b", true]], undef, "hello", false]
-// Example(NORENDER): pre-populating again, but with a simpler `vlist`:
+//   echo(obj_debug_obj(o));
+//   // emits: ECHO: "0: _toc_: Obj
+//   // 1: attr1 (i: undef): undef
+//   // 2: attr2 (s: undef): hello
+//   // 3: attr3 (b: true): false"
+// Example(NORENDER): pre-populating just as above, with the same attributes and values, but with a simpler `vlist`:
 //   o = Object("Obj", ["attr1=i", "attr2=s", "attr3=b=true"], ["attr2", "hello", "attr3", false]);
-//   echo(o);
-//   // emits: ECHO: [["Obj", ["attr1", "i", undef], ["attr2", "s", undef], ["attr3", "b", true]], undef, "hello", false]
-// Example(NORENDER): using `mutate` can carry values from a previous Object into a new one:
+//   echo(obj_debug_obj(o));
+//   // emits: ECHO: "0: _toc_: Obj
+//   // 1: attr1 (i: undef): undef
+//   // 2: attr2 (s: undef): hello
+//   // 3: attr3 (b: true): false"
+// Example(NORENDER): using `mutate` will carry values from a previous Object into a new one, with `vlist` values taking precedence:
 //   O_attrs = ["attr1=i", "attr2=s", "attr3=b=true"];
 //   o = Object("Obj", O_attrs, [["attr2", "hello"], ["attr3", false]]);
-//   echo(o);
+//   echo(obj_debug_obj(o));
 //   o2 = Object("Obj", O_attrs, vlist=["attr1", 12], mutate=o);
-//   echo(o2);
+//   echo(obj_debug_obj(o2));
 //   // emits:
-//   //   ECHO: [["Obj", ["attr1", "i", undef], ["attr2", "s", undef], ["attr3", "b", true]], undef, "hello", false]
-//   //   ECHO: [["Obj", ["attr1", "i", undef], ["attr2", "s", undef], ["attr3", "b", true]], 12, "hello", false]
-// See Also: ATTRIBUTE_DATA_TYPES
+//   // ECHO: "0: _toc_: Obj
+//   // 1: attr1 (i: undef): undef
+//   // 2: attr2 (s: undef): hello
+//   // 3: attr3 (b: true): false"
+//   // ECHO: "0: _toc_: Obj
+//   // 1: attr1 (i: undef): 12
+//   // 2: attr2 (s: undef): hello
+//   // 3: attr3 (b: true): false"
+// Example(NORENDER): when using `mutate`, you can specify an empty `attrs` list: the attributes will be carried over from the mutated Object:
+//   O_attrs = ["attr1=i", "attr2=s", "attr3=b=true"];
+//   o = Object("Obj", O_attrs, [["attr2", "hello"], ["attr3", false]]);
+//   echo(obj_debug_obj(o));
+//   o2 = Object("Obj", [], vlist=["attr1", 12], mutate=o);       // <-- an empty `attrs` list specified
+//   echo(obj_debug_obj(o2));
+//   // emits:
+//   // ECHO: "0: _toc_: Obj
+//   // 1: attr1 (i: undef): undef
+//   // 2: attr2 (s: undef): hello
+//   // 3: attr3 (b: true): false"
+//   // ECHO: "0: _toc_: Obj
+//   // 1: attr1 (i: undef): 12
+//   // 2: attr2 (s: undef): hello
+//   // 3: attr3 (b: true): false"
+//
+// See Also: obj_debug_obj(), ATTRIBUTE_DATA_TYPES
 // EXTERNAL - 
 //    is_list(), list_insert(), list_shape(), list_pad(), list_set() (BOSL2); 
 function Object(name, attrs=[], vlist=[], mutate=[]) =

--- a/object_common_functions.scad
+++ b/object_common_functions.scad
@@ -694,20 +694,6 @@ function obj_accessor_get(obj, name, nv=undef, default=undef, _consider_toc_defa
 //   obj = Object("ExampleObj", ["a1=i", "a2=i"], ["a1", 30]);
 //   new_obj = obj_accessor_set(obj, "a1", nv=20);
 //   // new_obj's `a1` attribute is now 20
-// Example(NORENDER): providing a class- and attribute-specific "glue" write-only accessor:
-//   function set_axle_length(axle, nv) = obj_accessor_set(axle, "length", nv);
-//   // ..
-//   axle = Axle([["diameter", 10], ["length", 30]]);
-//   new_axle = set_axle_length(axle, 40);
-//   // new_axle == [["Axle", "diameter", "length"], 10, 40];
-// Example(NORENDER): gotchas when setting undefined values with `obj_accessor()`:
-//   // Setting no value in `nv` will *not* do what you want!
-//   function set_axle_length(axle, nv=undef) = obj_accessor(axle, "length", nv);
-//   axle = Axle([["diameter", 10], ["length", 30]]);
-//   new_axle = set_axle_length(axle);
-//   // new_axle == 30  //<--- This is the `length` value, NOT a new object. 
-//   // Because the `nv` option wasn't provided, the call arrived into `obj_accessor()` as `undef`, and 
-//   // was treated as a "get". 
 // See Also: obj_accessor()
 function obj_accessor_set(obj, name, nv, default=undef) = 
     assert(_defined(name), str("obj_accessor_set(): attribute name must ",
@@ -1359,16 +1345,14 @@ function obj_toc_get_attr_default_by_id(obj, id) = obj_toc_get_attr_defaults(obj
 /// Continues:
 ///   It is an error to specify a `name` that isn't present within the TOC. It is an error to specify 
 ///   an Object without a valid TOC, or to pass a non-Object value as `obj` (such as a number).
-/// Example(NORENDER):
-///   axle = Axle([["diameter", 10], ["length", 30]]);
-///   // axle == [["Axle", ["diameter", "i"], ["length", "i"]], 10, 30];
-///   id = obj_toc_attr_id_by_name(axle, "diameter");
+/// Example(NORENDER): getting an attribute's ID from its name:
+///   obj = Object("ExampleObj", ["a1=i", "a2=i"], ["a1", 10, "a2", 30]);
+///   id = obj_toc_attr_id_by_name(obj, "a1");
 ///   // id == 1
-/// Example(NORENDER):
-///   axle = Axle([]);
-///   // axle == [["Axle", ["diameter", "i"], ["length", "i"]], undef, undef];
-///   id = obj_toc_attr_id_by_name(axle, "not-found");
-///   // error is thrown
+/// Example(NORENDER): requesting an attribute ID for an attribute name that doesn't exist yields an error:
+///   obj = Object("ExampleObj", ["a1=i", "a2=i"]);
+///   id = obj_toc_attr_id_by_name(obj, "not-found");
+///   // an error is thrown
 /// EXTERNAL - 
 ///   is_list() (BOSL2);
 function obj_toc_attr_id_by_name(obj, name) = 
@@ -1404,15 +1388,13 @@ function obj_toc_attr_id_by_name(obj, name) =
 /// Continues:
 ///   It is an error to specify an `id` that exceeds the attribute length within the TOC. It is an error to specify 
 ///   an Object without a valid TOC, or to pass a non-Object value as `obj` (such as a number).
-/// Example(NORENDER):
-///   axle = Axle([["diameter", 10], ["length", 30]]);
-///   // axle == [["Axle", "diameter", "length"], 10, 30];
-///   name = obj_toc_attr_name_by_id(axle, 1);
-///   // name == "diameter"
-/// Example(NORENDER):
-///   axle = Axle([]);
-///   // axle == [["Axle", "diameter", "length"], undef, undef];
-///   name = obj_toc_attr_name_by_id(axle, 3);
+/// Example(NORENDER): translating an attribute ID into the Object's attribute name:
+///   obj = Object("ExampleObj", ["a1=i", "a2=i"], ["a1", 10, "a2", 30]);
+///   name = obj_toc_attr_name_by_id(obj, 1);
+///   // name == "a1"
+/// Example(NORENDER): translating an attribute ID into the Object's attribute name for an ID that doesn't exist yields an error:
+///   obj = Object("ExampleObj", ["a1=i", "a2=i"], ["a1", 10, "a2", 30]);
+///   name = obj_toc_attr_name_by_id(obj, 3);
 ///   // error is thrown
 /// EXTERNAL - 
 ///   is_list() (BOSL2); 

--- a/object_common_functions.scad
+++ b/object_common_functions.scad
@@ -944,7 +944,7 @@ function obj_list_debug_obj(obj_list) = [ for (obj=obj_list) obj_debug_obj(obj) 
 //   A list of known attribute data types. "Types" in this context are 
 //   single-character symbols that indicate what the attribute is 
 //   meant to hold. 
-// Attributes:
+// Type IDs: The following data type IDs are known:
 //   s = literal strings. Example: `"a string"`. *(Note: Strings are always assigned with quotes and we show that here, but as elsewhere in OpenSCAD the quotes are not part of the string.)* 
 //   i = integers. Example: `1`
 //   b = booleans. Example: `true`

--- a/tests/test_03_object.scad
+++ b/tests/test_03_object.scad
@@ -12,9 +12,9 @@ function gen_test_type_object() =
     obj_accessor_set(_obj, "object", nv=_obj);
 
 
-module test_obj_build_toc() {
+module test_obj_toc_build() {
     // test string-based paired creation
-    toc = obj_build_toc("Test", ["one=i", "two=s"], []);
+    toc = obj_toc_build("Test", ["one=i", "two=s"], []);
     assert( obj_is_obj( [toc, undef, undef] ));
 
     assert( obj_toc_get_type([toc, undef, undef]) == "Test" );
@@ -22,18 +22,18 @@ module test_obj_build_toc() {
     assert( obj_toc_get_attr_names([toc, undef, undef]) == ["_toc_", "one", "two"] );
 
     // test mutate TOC propgation
-    mtoc = obj_build_toc("Test", ["three=i", "four=s"], [toc, undef, undef] );
+    mtoc = obj_toc_build("Test", ["three=i", "four=s"], [toc, undef, undef] );
     assert( obj_toc_get_type([mtoc, undef, undef]) == "Test" );
     assert( obj_toc_attr_len([mtoc, undef, undef]) == 2 );
     assert( obj_toc_get_attr_names([mtoc, undef, undef]) == ["_toc_", "one", "two"], toc);
 
     // test list-based paired TOC creation
-    ptoc = obj_build_toc("TestP", [["five", "i"], ["six", "s"]], []);
+    ptoc = obj_toc_build("TestP", [["five", "i"], ["six", "s"]], []);
     assert( obj_toc_get_type([ptoc, undef, undef]) == "TestP" );
     assert( obj_toc_attr_len([ptoc, undef, undef]) == 2 );
     assert( obj_toc_get_attr_names([ptoc, undef, undef]) == ["_toc_", "five", "six"] );
 }
-test_obj_build_toc();
+test_obj_toc_build();
 
 
 module test_test_type_obj() {

--- a/tests/test_03_object.scad
+++ b/tests/test_03_object.scad
@@ -45,22 +45,35 @@ module test_test_type_obj() {
 test_test_type_obj();
 
 
-module test_obj_data_types() {
+module test_data_type_is_valid() {
     assert( len(ATTRIBUTE_DATA_TYPES) > 0 );
 
-    assert( obj_type_is_valid("s") );
-    assert( obj_type_is_valid("i") );
-    assert( obj_type_is_valid("b") );
-    assert( obj_type_is_valid("l") );
-    assert( obj_type_is_valid("u") );
-    assert( obj_type_is_valid("o") );
+    assert( data_type_is_valid("s") );
+    assert( data_type_is_valid("i") );
+    assert( data_type_is_valid("b") );
+    assert( data_type_is_valid("l") );
+    assert( data_type_is_valid("u") );
+    assert( data_type_is_valid("o") );
 }
-test_obj_data_types();
+test_data_type_is_valid();
+
+
+module test_obj_data_type_is_valid() {
+    obj = gen_test_type_object();
+    assert( obj_data_type_is_valid(obj, "string") );
+    assert( obj_data_type_is_valid(obj, "integer") );
+    assert( obj_data_type_is_valid(obj, "boolean") );
+    assert( obj_data_type_is_valid(obj, "list") );
+    assert( obj_data_type_is_valid(obj, "undefined") );
+    assert( obj_data_type_is_valid(obj, "object") );
+}
+test_obj_data_type_is_valid();
 
 
 module test_obj_type_check_value() {
     obj = gen_test_type_object();
 
+    assert( obj_type_check_value(obj, "string") );
     assert( obj_type_check_value(obj, "string", "abcd") );
     assert( obj_type_check_value(obj, "string", "    ") );
     assert( obj_type_check_value(obj, "string", "	") );   // a literal tab
@@ -70,6 +83,7 @@ module test_obj_type_check_value() {
     assert( obj_type_check_value(obj, "string", "0") );
     assert( obj_type_check_value(obj, "string", "undef") );
 
+    assert( obj_type_check_value(obj, "integer") );
     assert( obj_type_check_value(obj, "integer", 1) );
     assert( obj_type_check_value(obj, "integer", 0) );
     assert( obj_type_check_value(obj, "integer", -1) );
@@ -78,16 +92,20 @@ module test_obj_type_check_value() {
     assert( obj_type_check_value(obj, "integer", 65535) );
     assert( obj_type_check_value(obj, "integer", -65535) );
 
+    assert( obj_type_check_value(obj, "boolean") );
     assert( obj_type_check_value(obj, "boolean", true) );
     assert( obj_type_check_value(obj, "boolean", false) );
 
+    assert( obj_type_check_value(obj, "list") );
     assert( obj_type_check_value(obj, "list", []) );
     assert( obj_type_check_value(obj, "list", [1, 2]) );
     assert( obj_type_check_value(obj, "list", [1, [4]]) );
 
+    assert( obj_type_check_value(obj, "undefined") );
     assert( obj_type_check_value(obj, "undefined", undef) );
 
     // TODO: when we've got workings to compare object types, augment here.
+    assert( obj_type_check_value(obj, "object") );
     assert( obj_type_check_value(obj, "object", obj) );
 }
 test_obj_type_check_value();

--- a/tests/test_03_object.scad
+++ b/tests/test_03_object.scad
@@ -154,6 +154,17 @@ module test_construction() {
 test_construction();
 
 
+module test_mutate() {
+    o = Object("O", ["a1=i", "a2=i"], ["a1", 10, "a2", 12]);
+    o2 = Object("O", [], vlist=["a2", 13], mutate=o);
+
+    assert(obj_toc(o) == obj_toc(o2));
+
+    assert(obj_accessor_get(o2, "a2") == 13);
+}
+test_mutate();
+
+
 module test_obj_accessor() {
     function D(vlist=[], mutate=[]) = Object( "D", 
         ["string=s", "integer=i", "boolean=b", "list=l", "undefined=u", "object=o"],


### PR DESCRIPTION
Big ole' honkin' update to documentation. 

* removal of "Axle" object examples
* reordering of functions to be user-oriented: things they need up front, things they don't down below
* TOC functions, support functions hidden from public documentation
* bugfix: https://github.com/jon-gilbert/openscad_objects/issues/18
* data type function names reworked a bit (but nothing that *should* be used outside this module)
* obj_accessor() examples that reference subclassing into other object-specific implementations removed: we'll have to flesh out the HOWTO examples better, but providing example of pseudocode or implementation specific code in this file only adds to confusion.
* new function: obj_get_names() (to compliment obj_get_values())
* all Example: blocks tagged (NORENDER)
